### PR TITLE
Add fixed-step simulation harness with deterministic EditMode tests

### DIFF
--- a/Assets/Scripts/Simulation/DummyDeterministicSimulationSystem.cs
+++ b/Assets/Scripts/Simulation/DummyDeterministicSimulationSystem.cs
@@ -1,0 +1,24 @@
+namespace FactoryMustScale.Simulation
+{
+    public struct DummySimulationState
+    {
+        public int Counter;
+        public int Checksum;
+    }
+
+    public struct DummyDeterministicSimulationSystem : ISimulationSystem<DummySimulationState>
+    {
+        private const int CounterStep = 3;
+        private const int ChecksumMultiplier = 1664525;
+        private const int ChecksumIncrement = 1013904223;
+
+        public void Tick(ref DummySimulationState state, int tickIndex)
+        {
+            unchecked
+            {
+                state.Counter += CounterStep;
+                state.Checksum = (state.Checksum * ChecksumMultiplier) + ChecksumIncrement + state.Counter + tickIndex;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/DummyDeterministicSimulationSystem.cs
+++ b/Assets/Scripts/Simulation/DummyDeterministicSimulationSystem.cs
@@ -1,11 +1,44 @@
 namespace FactoryMustScale.Simulation
 {
+    /// <summary>
+    /// Minimal runtime state used by the dummy system.
+    ///
+    /// Why this struct exists:
+    /// - Demonstrates the project rule that runtime simulation state should be plain data (no Unity references).
+    /// - Keeps the deterministic baseline easy to inspect and serialize later.
+    /// </summary>
     public struct DummySimulationState
     {
         public int Counter;
         public int Checksum;
     }
 
+    /// <summary>
+    /// A tiny deterministic system used as a harness baseline.
+    ///
+    /// Why this class exists:
+    /// - Provides a concrete non-Unity simulation workload for EditMode verification.
+    /// - Makes deterministic behavior measurable with exact expected values.
+    ///
+    /// Fixed-step behavior:
+    /// - Performs exactly one deterministic state transition for each harness tick.
+    /// - Depends only on current state and explicit tick index input.
+    ///
+    /// Determinism strategy:
+    /// - Uses only integer math and constants.
+    /// - Uses <c>unchecked</c> arithmetic so overflow behavior is explicit and repeatable.
+    ///
+    /// Forbidden-construct avoidance:
+    /// - No allocations in <c>Tick</c>.
+    /// - No LINQ, no <c>foreach</c>, no UnityEngine API calls, no GetComponent.
+    ///
+    /// Assumptions:
+    /// - Integer overflow semantics remain the same in target runtime (standard C# unchecked behavior).
+    ///
+    /// Possible improvement relative to rules:
+    /// - Replace this toy transition with real system state arrays once factory-layer simulation begins,
+    ///   while preserving deterministic indexed iteration and allocation-free hot path.
+    /// </summary>
     public struct DummyDeterministicSimulationSystem : ISimulationSystem<DummySimulationState>
     {
         private const int CounterStep = 3;

--- a/Assets/Scripts/Simulation/FixedStepSimulationHarness.cs
+++ b/Assets/Scripts/Simulation/FixedStepSimulationHarness.cs
@@ -2,6 +2,31 @@ using System;
 
 namespace FactoryMustScale.Simulation
 {
+    /// <summary>
+    /// Executes a simulation system on a deterministic fixed tick sequence.
+    ///
+    /// Why this class exists:
+    /// - Provides the smallest reusable harness needed to run pure simulation logic outside MonoBehaviours.
+    /// - Encodes fixed-step progression explicitly as integer ticks, matching project rules that simulation must not be frame-driven.
+    ///
+    /// Determinism strategy:
+    /// - Stable, indexed <c>for</c> loop for tick progression.
+    /// - Monotonic integer tick counter passed into the system each step.
+    /// - No dependence on time delta, rendering loop, or unordered data structures.
+    ///
+    /// Forbidden-construct avoidance:
+    /// - No UnityEngine APIs.
+    /// - No LINQ, no <c>foreach</c>, no per-tick heap allocation in this loop.
+    /// - System instance is a struct generic to avoid interface boxing during tick calls.
+    ///
+    /// Assumptions:
+    /// - <typeparamref name="TSystem"/> is deterministic and does not allocate in its <c>Tick</c> path.
+    /// - <typeparamref name="TState"/> shape is controlled by caller and should remain serializable-friendly.
+    ///
+    /// Possible improvement relative to rules:
+    /// - Current API applies only state-update phase; future revision can model input ingestion and output extraction explicitly
+    ///   while preserving fixed-step and allocation-free operation.
+    /// </summary>
     public sealed class FixedStepSimulationHarness<TState, TSystem>
         where TSystem : struct, ISimulationSystem<TState>
     {

--- a/Assets/Scripts/Simulation/FixedStepSimulationHarness.cs
+++ b/Assets/Scripts/Simulation/FixedStepSimulationHarness.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace FactoryMustScale.Simulation
+{
+    public sealed class FixedStepSimulationHarness<TState, TSystem>
+        where TSystem : struct, ISimulationSystem<TState>
+    {
+        private TState _state;
+        private TSystem _system;
+        private int _currentTick;
+
+        public FixedStepSimulationHarness(TState initialState, TSystem system)
+        {
+            _state = initialState;
+            _system = system;
+            _currentTick = 0;
+        }
+
+        public int CurrentTick => _currentTick;
+
+        public TState State => _state;
+
+        public void Tick(int tickCount)
+        {
+            if (tickCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(tickCount));
+            }
+
+            for (int i = 0; i < tickCount; i++)
+            {
+                _system.Tick(ref _state, _currentTick);
+                _currentTick++;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/ISimulationSystem.cs
+++ b/Assets/Scripts/Simulation/ISimulationSystem.cs
@@ -1,0 +1,7 @@
+namespace FactoryMustScale.Simulation
+{
+    public interface ISimulationSystem<TState>
+    {
+        void Tick(ref TState state, int tickIndex);
+    }
+}

--- a/Assets/Scripts/Simulation/ISimulationSystem.cs
+++ b/Assets/Scripts/Simulation/ISimulationSystem.cs
@@ -1,5 +1,20 @@
 namespace FactoryMustScale.Simulation
 {
+    /// <summary>
+    /// Minimal simulation contract for fixed-step systems.
+    ///
+    /// Rationale (AGENTS.md + Docs/SimRules.md):
+    /// - Exists to isolate pure simulation from Unity-facing adapters.
+    /// - Accepts state by <c>ref</c> and an explicit tick index to keep update order explicit and deterministic.
+    /// - Avoids forbidden constructs by design: no UnityEngine dependency, no LINQ, no collection iteration policy hidden in the API.
+    ///
+    /// Assumption:
+    /// - Implementers are pure and deterministic for equal initial state + equal tick sequence.
+    ///
+    /// Expansion path:
+    /// - Keep this contract stable and add optional input/output buffers as additional parameters when input ingestion
+    ///   and output extraction phases are introduced (without changing fixed-step semantics).
+    /// </summary>
     public interface ISimulationSystem<TState>
     {
         void Tick(ref TState state, int tickIndex);

--- a/Assets/Tests/EditMode/SimulationHarnessDeterminismTests.cs
+++ b/Assets/Tests/EditMode/SimulationHarnessDeterminismTests.cs
@@ -1,0 +1,86 @@
+using FactoryMustScale.Simulation;
+using NUnit.Framework;
+using System;
+
+namespace FactoryMustScale.Tests.EditMode
+{
+    public sealed class SimulationHarnessDeterminismTests
+    {
+        [Test]
+        public void DummySystem_ReachesExpectedFinalState_AfterFixedTickCount()
+        {
+            const int ticksToRun = 128;
+
+            var initialState = new DummySimulationState
+            {
+                Counter = 1,
+                Checksum = 7,
+            };
+
+            var harness = new FixedStepSimulationHarness<DummySimulationState, DummyDeterministicSimulationSystem>(
+                initialState,
+                new DummyDeterministicSimulationSystem());
+
+            harness.Tick(ticksToRun);
+
+            Assert.That(harness.CurrentTick, Is.EqualTo(ticksToRun));
+            Assert.That(harness.State.Counter, Is.EqualTo(385));
+            Assert.That(harness.State.Checksum, Is.EqualTo(1474803079));
+        }
+
+        [Test]
+        public void DummySystem_IsDeterministic_ForSameInitialStateAndTickCount()
+        {
+            const int ticksToRun = 256;
+
+            var initialState = new DummySimulationState
+            {
+                Counter = 10,
+                Checksum = 42,
+            };
+
+            var firstHarness = new FixedStepSimulationHarness<DummySimulationState, DummyDeterministicSimulationSystem>(
+                initialState,
+                new DummyDeterministicSimulationSystem());
+
+            var secondHarness = new FixedStepSimulationHarness<DummySimulationState, DummyDeterministicSimulationSystem>(
+                initialState,
+                new DummyDeterministicSimulationSystem());
+
+            firstHarness.Tick(ticksToRun);
+            secondHarness.Tick(ticksToRun);
+
+            Assert.That(firstHarness.State.Counter, Is.EqualTo(secondHarness.State.Counter));
+            Assert.That(firstHarness.State.Checksum, Is.EqualTo(secondHarness.State.Checksum));
+        }
+
+        [Test]
+        public void DummySystem_AllocatesZeroBytes_PerTickAfterWarmup()
+        {
+            const int warmupTicks = 16;
+            const int measuredTicks = 256;
+
+            var initialState = new DummySimulationState
+            {
+                Counter = 3,
+                Checksum = 5,
+            };
+
+            var harness = new FixedStepSimulationHarness<DummySimulationState, DummyDeterministicSimulationSystem>(
+                initialState,
+                new DummyDeterministicSimulationSystem());
+
+            harness.Tick(warmupTicks);
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+
+            long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            harness.Tick(measuredTicks);
+            long allocatedAfter = GC.GetAllocatedBytesForCurrentThread();
+
+            Assert.That(allocatedAfter - allocatedBefore, Is.EqualTo(0));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/SimulationHarnessDeterminismTests.cs
+++ b/Assets/Tests/EditMode/SimulationHarnessDeterminismTests.cs
@@ -4,6 +4,21 @@ using System;
 
 namespace FactoryMustScale.Tests.EditMode
 {
+    /// <summary>
+    /// EditMode tests that codify baseline simulation constraints from AGENTS.md and Docs/SimRules.md.
+    ///
+    /// Why this test suite exists:
+    /// - Guards fixed-step behavior through explicit tick-count assertions.
+    /// - Guards determinism through repeat-run equivalence checks.
+    /// - Guards hot-path memory behavior through per-tick allocation checks.
+    ///
+    /// Assumptions:
+    /// - <see cref="GC.GetAllocatedBytesForCurrentThread"/> is available in the target Unity/.NET runtime.
+    /// - Allocation test executes on one thread and reflects managed allocations for this workload.
+    ///
+    /// Possible improvement relative to rules:
+    /// - Add additional deterministic scenarios with explicit input-buffer snapshots once ingestion/extraction phases are added.
+    /// </summary>
     public sealed class SimulationHarnessDeterminismTests
     {
         [Test]


### PR DESCRIPTION
### Motivation
- Provide a minimal, deterministic fixed-step simulation harness to satisfy `Docs/SimRules.md` requirements for fixed ticks and determinism.
- Supply a simple concrete system and tests to validate tick progression, determinism, and zero GC allocations per tick as an initial correctness baseline.
- Keep simulation code free of Unity APIs, `Update()`, LINQ, and heap allocations in per-tick paths to follow project constraints.

### Description
- Added a lightweight simulation contract `ISimulationSystem<TState>` under `Assets/Scripts/Simulation/` with a single `Tick(ref TState state, int tickIndex)` method.
- Implemented a generic `FixedStepSimulationHarness<TState, TSystem>` that advances simulation state by an indexed, deterministic loop and exposes `CurrentTick` and `State` accessors.
- Implemented a `DummyDeterministicSimulationSystem` and `DummySimulationState` as plain structs that perform stable integer arithmetic inside `unchecked` to produce deterministic results without allocations or Unity APIs.
- Added EditMode tests in `Assets/Tests/EditMode/SimulationHarnessDeterminismTests.cs` that assert expected final state after `N` ticks, determinism across identical runs, and zero managed allocations during measured ticks.
- Followed the repository rules by avoiding `foreach`/LINQ/`GetComponent`/UnityEngine calls in the simulation code and keeping simulation logic in POCO structs and arrays.

### Testing
- Performed static checks for forbidden APIs and patterns in the new files to ensure no `Update()`, `LINQ`, `GetComponent`, or `UnityEngine` usage was introduced, and found none in the simulation sources.
- Reproduced the expected numeric final state with a small Python script to compute the checksum used in test assertions to ensure test values are correct.
- Committed the harness, system, and EditMode tests into branch `feature/issue-0-sim-harness` and validated repository state via Git commands in this environment.
- Note: Unity EditMode tests could not be executed in this container because the Unity Test Runner is not available here, so the `NUnit` tests should be run in the target Unity Editor where they are expected to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aabd229108327b79b81d254ce30e5)