### PR TITLE
Fix tick coroutine to process missed quarter-second ticks

### DIFF
--- a/Assets/Scripts/Visualization/MinimalFactoryTickCoroutineDriver.cs
+++ b/Assets/Scripts/Visualization/MinimalFactoryTickCoroutineDriver.cs
@@ -51,7 +51,7 @@ namespace FactoryMustScale.Visualization
             while (enabled)
             {
                 float now = Time.realtimeSinceStartup;
-                if (now >= nextTickTime)
+                while (now >= nextTickTime)
                 {
                     _onTick?.Invoke();
                     nextTickTime += interval;


### PR DESCRIPTION
### Motivation
- The PlayMode test `TickCoroutineDriver_InvokesTickRoughlyEveryQuarterSecond` observed only one tick instead of three because the coroutine only emitted a single tick per frame when frames were delayed. 
- The intent is to make the tick driver catch up after stalls so the expected number of 0.25s ticks are delivered during PlayMode runs.

### Description
- Replaced the single-check `if (now >= nextTickTime)` with a catch-up loop `while (now >= nextTickTime)` in `MinimalFactoryTickCoroutineDriver.TickLoop`, located in `Assets/Scripts/Visualization/MinimalFactoryTickCoroutineDriver.cs`, so all missed intervals are invoked before yielding. 
- Known limitation: this can emit multiple ticks in one frame after a long stall, producing bursty callback execution; next logical step is to consider a configurable max catch-up cap if burst work becomes problematic.

### Testing
- No Unity PlayMode tests were executed in this environment because Unity is not installed (`unity-editor -version` and `Unity -version` both failed), so automated PlayMode verification could not run here. 
- Please run the PlayMode test `TickCoroutineDriver_InvokesTickRoughlyEveryQuarterSecond` in CI or locally to confirm it now reports `tickCount >= 3` after `yield return new WaitForSecondsRealtime(0.80f)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d65b0656083278935e9368514c4a8)