### PR TITLE
Make tick driver catch up missed ticks and stabilize PlayMode timing test

### DIFF
--- a/Assets/Scripts/Visualization/MinimalFactoryTickCoroutineDriver.cs
+++ b/Assets/Scripts/Visualization/MinimalFactoryTickCoroutineDriver.cs
@@ -51,7 +51,7 @@ namespace FactoryMustScale.Visualization
             while (enabled)
             {
                 float now = Time.realtimeSinceStartup;
-                if (now >= nextTickTime)
+                while (now >= nextTickTime)
                 {
                     _onTick?.Invoke();
                     nextTickTime += interval;

--- a/Assets/Tests/PlayMode/VisualizationPlayModeTests.cs
+++ b/Assets/Tests/PlayMode/VisualizationPlayModeTests.cs
@@ -19,7 +19,11 @@ namespace FactoryMustScale.Tests.PlayMode
             driver.enabled = true;
             driver.StartTickLoop(() => tickCount++);
 
-            yield return new WaitForSecondsRealtime(0.80f);
+            float timeoutAt = Time.realtimeSinceStartup + 1.50f;
+            while (tickCount < 3 && Time.realtimeSinceStartup < timeoutAt)
+            {
+                yield return null;
+            }
 
             driver.StopTickLoop();
 


### PR DESCRIPTION
### Motivation
- Ensure the tick coroutine delivers all missed quarter-second ticks after frame stalls so the visualization driver behaves predictably under scheduler delays.
- Stabilize the PlayMode timing test so it does not rely on a fragile fixed realtime delay that can race with coroutine scheduling.

### Description
- In `Assets/Scripts/Visualization/MinimalFactoryTickCoroutineDriver.cs` the `TickLoop` now uses `while (now >= nextTickTime)` instead of a single `if` check so missed intervals are processed in a catch-up loop that repeatedly invokes `_onTick` and advances `nextTickTime`.
- In `Assets/Tests/PlayMode/VisualizationPlayModeTests.cs` the `TickCoroutineDriver_InvokesTickRoughlyEveryQuarterSecond` test replaces the single `yield return new WaitForSecondsRealtime(0.80f);` with a frame-polling loop that waits `yield return null` until `tickCount >= 3` or a realtime timeout is reached.
- These changes make the driver more correct under delayed frames and make the PlayMode test robust to Unity Test Framework coroutine ordering.

### Testing
- No Unity PlayMode tests were executed in this environment because the Unity CLI/editor is not available, so automated PlayMode verification could not be run here and no tests were run locally against the editor.
- Please run the PlayMode test `TickCoroutineDriver_InvokesTickRoughlyEveryQuarterSecond` in CI or locally to verify it consistently observes at least three ticks within the timeout window.
- Known limitation: the catch-up loop can emit multiple ticks in one frame after long stalls, producing bursty callbacks and potential frame work spikes.
- Next logical steps: consider a configurable max catch-up cap or extract a pure C# tick scheduler for fast deterministic EditMode tests and further unit coverage.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d65b0656083278935e9368514c4a8)