### PR TITLE
Fix process recipe dimensions for outputs and resource deltas

### DIFF
--- a/Assets/Scripts/Authoring/FactoryCellProcessDefinition.cs
+++ b/Assets/Scripts/Authoring/FactoryCellProcessDefinition.cs
@@ -1,0 +1,166 @@
+using FactoryMustScale.Simulation;
+using UnityEngine;
+
+namespace FactoryMustScale.Authoring
+{
+    [System.Serializable]
+    public struct FactoryProcessSlotDefinition
+    {
+        public CardinalDirectionMask Directions;
+        public int ItemIdFilter;
+        public int MaxItemsPerTick;
+    }
+
+    [System.Serializable]
+    public struct ProcessItemStackDefinition
+    {
+        public int ItemId;
+        public int Amount;
+    }
+
+    [System.Serializable]
+    public struct ProcessResourceDeltaDefinition
+    {
+        public ProcessResourceType ResourceType;
+        public int Amount;
+    }
+
+    [System.Serializable]
+    public struct FactoryProcessRecipeDefinition
+    {
+        public ProcessItemStackDefinition[] ItemInputs;
+        public ProcessItemStackDefinition[] ItemOutputs;
+        public ProcessResourceDeltaDefinition[] ResourceDeltas;
+    }
+
+    [CreateAssetMenu(
+        fileName = "FactoryCellProcessDefinition",
+        menuName = "FactoryMustScale/Definitions/Factory Cell Process")]
+    public sealed class FactoryCellProcessDefinition : ScriptableObject
+    {
+        [SerializeField]
+        private GridStateId _stateId = GridStateId.Empty;
+
+        [SerializeField]
+        private FactoryProcessType _processType = FactoryProcessType.None;
+
+        [SerializeField, Min(1)]
+        private int _processDurationTicks = 1;
+
+        [SerializeField]
+        private int _processProgressPayloadChannelIndex = -1;
+
+        [SerializeField]
+        private FactoryProcessSlotDefinition[] _inputSlots;
+
+        [SerializeField]
+        private FactoryProcessSlotDefinition[] _outputSlots;
+
+        [SerializeField]
+        private FactoryProcessRecipeDefinition[] _recipes;
+
+        public GridStateId StateId => _stateId;
+        public FactoryProcessType ProcessType => _processType;
+        public int ProcessDurationTicks => _processDurationTicks;
+        public int ProcessProgressPayloadChannelIndex => _processProgressPayloadChannelIndex;
+        public FactoryProcessSlotDefinition[] InputSlots => _inputSlots;
+        public FactoryProcessSlotDefinition[] OutputSlots => _outputSlots;
+        public FactoryProcessRecipeDefinition[] Recipes => _recipes;
+
+        public FactoryCellProcessData BakeToRuntimeData()
+        {
+            var data = new FactoryCellProcessData
+            {
+                StateId = (int)_stateId,
+                ProcessType = _processType,
+                ProcessDurationTicks = _processDurationTicks > 0 ? _processDurationTicks : 1,
+                ProcessProgressPayloadChannelIndex = _processProgressPayloadChannelIndex,
+                InputSlots = BakeSlots(_inputSlots),
+                OutputSlots = BakeSlots(_outputSlots),
+                Recipes = BakeRecipes(_recipes),
+            };
+
+            return data;
+        }
+
+        private static FactoryProcessSlotData[] BakeSlots(FactoryProcessSlotDefinition[] definitions)
+        {
+            if (definitions == null || definitions.Length == 0)
+            {
+                return new FactoryProcessSlotData[0];
+            }
+
+            var data = new FactoryProcessSlotData[definitions.Length];
+            for (int i = 0; i < definitions.Length; i++)
+            {
+                data[i].Directions = definitions[i].Directions;
+                data[i].ItemIdFilter = definitions[i].ItemIdFilter;
+                data[i].MaxItemsPerTick = definitions[i].MaxItemsPerTick;
+            }
+
+            return data;
+        }
+
+        private static FactoryProcessRecipeData[] BakeRecipes(FactoryProcessRecipeDefinition[] definitions)
+        {
+            if (definitions == null || definitions.Length == 0)
+            {
+                return new FactoryProcessRecipeData[0];
+            }
+
+            var data = new FactoryProcessRecipeData[definitions.Length];
+            for (int i = 0; i < definitions.Length; i++)
+            {
+                data[i].ItemInputs = BakeItemStacks(
+                    definitions[i].ItemInputs,
+                    FactoryProcessRecipeData.ItemInputCount);
+
+                data[i].ItemOutputs = BakeItemStacks(
+                    definitions[i].ItemOutputs,
+                    FactoryProcessRecipeData.ItemOutputCount);
+
+                data[i].ResourceDeltas = BakeResourceDeltas(
+                    definitions[i].ResourceDeltas,
+                    FactoryProcessRecipeData.ResourceDeltaCount);
+            }
+
+            return data;
+        }
+
+        private static ProcessItemStackData[] BakeItemStacks(ProcessItemStackDefinition[] definitions, int fixedLength)
+        {
+            var data = new ProcessItemStackData[fixedLength];
+            if (definitions == null || definitions.Length == 0)
+            {
+                return data;
+            }
+
+            int count = definitions.Length < fixedLength ? definitions.Length : fixedLength;
+            for (int i = 0; i < count; i++)
+            {
+                data[i].ItemId = definitions[i].ItemId;
+                data[i].Amount = definitions[i].Amount;
+            }
+
+            return data;
+        }
+
+        private static ProcessResourceDeltaData[] BakeResourceDeltas(ProcessResourceDeltaDefinition[] definitions, int fixedLength)
+        {
+            var data = new ProcessResourceDeltaData[fixedLength];
+            if (definitions == null || definitions.Length == 0)
+            {
+                return data;
+            }
+
+            int count = definitions.Length < fixedLength ? definitions.Length : fixedLength;
+            for (int i = 0; i < count; i++)
+            {
+                data[i].ResourceType = definitions[i].ResourceType;
+                data[i].Amount = definitions[i].Amount;
+            }
+
+            return data;
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/FactoryCellProcessData.cs
+++ b/Assets/Scripts/Simulation/FactoryCellProcessData.cs
@@ -1,0 +1,94 @@
+using System;
+
+namespace FactoryMustScale.Simulation
+{
+    [Flags]
+    public enum CardinalDirectionMask : byte
+    {
+        None = 0,
+        Up = 1 << 0,
+        Right = 1 << 1,
+        Down = 1 << 2,
+        Left = 1 << 3,
+        All = Up | Right | Down | Left,
+    }
+
+    public enum FactoryProcessType : byte
+    {
+        None = 0,
+        PassThrough = 1,
+        Extract = 2,
+        Craft = 3,
+        GeneratePower = 4,
+        ConsumePower = 5,
+        ConvertPower = 6,
+    }
+
+    public enum ProcessResourceType : byte
+    {
+        None = 0,
+        ElectricPower = 1,
+        Heat = 2,
+        MechanicalWork = 3,
+        Reserved = 255,
+    }
+
+    [Serializable]
+    public struct FactoryProcessSlotData
+    {
+        public CardinalDirectionMask Directions;
+        public int ItemIdFilter;
+        public int MaxItemsPerTick;
+    }
+
+    [Serializable]
+    public struct ProcessItemStackData
+    {
+        public int ItemId;
+        public int Amount;
+    }
+
+    [Serializable]
+    public struct ProcessResourceDeltaData
+    {
+        public ProcessResourceType ResourceType;
+        // Positive values produce resource, negative values consume resource.
+        public int Amount;
+    }
+
+    [Serializable]
+    public struct FactoryProcessRecipeData
+    {
+        public const int ItemInputCount = 3;
+        public const int ItemOutputCount = 2;
+        public const int ResourceDeltaCount = 4;
+
+        // Fixed-size recipe item and resource dimensions for deterministic data layout.
+        public ProcessItemStackData[] ItemInputs;
+        public ProcessItemStackData[] ItemOutputs;
+        public ProcessResourceDeltaData[] ResourceDeltas;
+    }
+
+    /// <summary>
+    /// Baked runtime process definition for one factory state id.
+    /// Dynamic counters (for example process progress) must live in layer payload channels.
+    /// </summary>
+    [Serializable]
+    public struct FactoryCellProcessData
+    {
+        public int StateId;
+        public FactoryProcessType ProcessType;
+
+        // Number of simulation ticks required for one process cycle.
+        // Use value 1 for one-tick transfer cells such as basic conveyors.
+        public int ProcessDurationTicks;
+
+        // Factory-layer payload channel index where per-cell process progress is stored.
+        // A negative value means this state does not use progress tracking.
+        public int ProcessProgressPayloadChannelIndex;
+
+        public FactoryProcessSlotData[] InputSlots;
+        public FactoryProcessSlotData[] OutputSlots;
+        public FactoryProcessRecipeData[] Recipes;
+    }
+}

--- a/Assets/Scripts/Simulation/FactoryProcessExamples.cs
+++ b/Assets/Scripts/Simulation/FactoryProcessExamples.cs
@@ -1,0 +1,39 @@
+namespace FactoryMustScale.Simulation
+{
+    /// <summary>
+    /// Small curated examples for authoring/runtime process presets.
+    /// These helpers are intended for tests and bootstrap wiring.
+    /// </summary>
+    public static class FactoryProcessExamples
+    {
+        public static FactoryCellProcessData CreateBasicConveyorProcessData()
+        {
+            FactoryCellProcessData data = new FactoryCellProcessData
+            {
+                StateId = (int)GridStateId.Conveyor,
+                ProcessType = FactoryProcessType.PassThrough,
+                ProcessDurationTicks = 1,
+                ProcessProgressPayloadChannelIndex = -1,
+                InputSlots = new FactoryProcessSlotData[1],
+                OutputSlots = new FactoryProcessSlotData[1],
+                Recipes = new FactoryProcessRecipeData[0],
+            };
+
+            data.InputSlots[0] = new FactoryProcessSlotData
+            {
+                Directions = CardinalDirectionMask.All,
+                ItemIdFilter = 0,
+                MaxItemsPerTick = 1,
+            };
+
+            data.OutputSlots[0] = new FactoryProcessSlotData
+            {
+                Directions = CardinalDirectionMask.All,
+                ItemIdFilter = 0,
+                MaxItemsPerTick = 1,
+            };
+
+            return data;
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/GridCellData.cs
+++ b/Assets/Scripts/Simulation/GridCellData.cs
@@ -30,6 +30,8 @@ namespace FactoryMustScale.Simulation
     /// Payload note:
     /// - Optional per-cell dynamic payload data should live in layer-owned payload channels that share
     ///   the same index scheme, keeping this struct compact and cache-friendly.
+    /// - Process systems should store dynamic counters (for example process progress ticks) in payload
+    ///   channels, while this struct stores the static process profile id in VariantCode bits.
     /// </summary>
     public struct GridCellData
     {
@@ -103,11 +105,29 @@ namespace FactoryMustScale.Simulation
             return (byte)((variantId >> VariantCodeShift) & VariantCodeMask);
         }
 
+        /// <summary>
+        /// Reads the process profile id packed in VariantCode bits.
+        /// This value maps a placed factory cell to one baked process definition.
+        /// </summary>
+        public static byte GetProcessProfileId(int variantId)
+        {
+            return GetVariantCode(variantId);
+        }
+
         public static int SetVariantCode(int variantId, byte variantCode)
         {
             int normalizedVariantCode = variantCode & VariantCodeMask;
             int clearedVariantId = variantId & ~(VariantCodeMask << VariantCodeShift);
             return clearedVariantId | (normalizedVariantCode << VariantCodeShift);
+        }
+
+        /// <summary>
+        /// Packs the process profile id into VariantCode bits.
+        /// Dynamic process progress should be stored in layer payload channels.
+        /// </summary>
+        public static int SetProcessProfileId(int variantId, byte processProfileId)
+        {
+            return SetVariantCode(variantId, processProfileId);
         }
 
         public static int GetConstructionDestructionStage(int variantId)

--- a/Assets/Scripts/Simulation/MinimalFactoryGameLoop.cs
+++ b/Assets/Scripts/Simulation/MinimalFactoryGameLoop.cs
@@ -9,8 +9,11 @@ namespace FactoryMustScale.Simulation
 
     public struct MinimalFactoryGameState
     {
+        public const int DefaultFactoryPayloadItemChannel = 0;
+
         public int Seed;
         public int TerrainResourceChannelIndex;
+        public int FactoryPayloadItemChannelIndex;
         public int MaxFactoryTicks;
         public int FactoryTicksExecuted;
         public MinimalFactoryGamePhase Phase;
@@ -21,6 +24,26 @@ namespace FactoryMustScale.Simulation
         public FactoryCommandResultBuffer CommandResults;
         public FactoryFootprintData[] Footprints;
         public bool StopProcessingOnFailure;
+
+        // Conveyor payload scratch buffers.
+        // These arrays are preallocated and reused every tick to avoid hot-path allocations.
+        public int[] ConveyorPayloadRead;
+        public int[] ConveyorPayloadWrite;
+
+        // Intent bookkeeping.
+        // - ConveyorIntentTargetBySource: source cell index -> target cell index (or -1 when no intent).
+        // - ConveyorWinnerSourceByTarget: target cell index -> winning source index (or -1 when no winner).
+        public int[] ConveyorIntentTargetBySource;
+        public int[] ConveyorWinnerSourceByTarget;
+
+        // Resolution bookkeeping.
+        // - ConveyorWinningTargetBySource: source cell index -> target when source won arbitration.
+        // - ConveyorCanExecuteMoveBySource: source cell index -> 1 if move executes this tick, else 0.
+        public int[] ConveyorWinningTargetBySource;
+        public byte[] ConveyorCanExecuteMoveBySource;
+
+        // Cycle-detection scratch data used during phase-2 resolution.
+        public int[] ConveyorVisitStampBySource;
     }
 
     /// <summary>
@@ -55,12 +78,330 @@ namespace FactoryMustScale.Simulation
             state.CommandResults.Clear();
             ApplyQueuedCommands(ref state, tickIndex);
             state.CommandQueue.Clear();
+            RunConveyorPayloadPhase(ref state);
 
             state.FactoryTicksExecuted++;
 
             if (state.FactoryTicksExecuted >= state.MaxFactoryTicks)
             {
                 state.Phase = MinimalFactoryGamePhase.Ended;
+            }
+        }
+
+        /// <summary>
+        /// Runs deterministic conveyor payload movement in three explicit phases:
+        /// 1) Intention + target arbitration
+        /// 2) Execution-resolution propagation (supports same-tick chain movement)
+        /// 3) Commit resolved payload changes back to the layer payload channel
+        ///
+        /// This keeps behavior deterministic and allocation-free in the hot path.
+        /// </summary>
+        private static void RunConveyorPayloadPhase(ref MinimalFactoryGameState state)
+        {
+            int payloadChannel = state.FactoryPayloadItemChannelIndex;
+            if (payloadChannel < 0)
+            {
+                payloadChannel = MinimalFactoryGameState.DefaultFactoryPayloadItemChannel;
+            }
+
+            if (state.FactoryLayer == null || payloadChannel >= state.FactoryLayer.PayloadChannelCount)
+            {
+                return;
+            }
+
+            int width = state.FactoryLayer.Width;
+            int height = state.FactoryLayer.Height;
+            int cellCount = width * height;
+
+            EnsureConveyorBuffers(ref state, cellCount);
+
+            // Snapshot read-buffer + initialize write-buffer to current payload values.
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = state.FactoryLayer.MinX + localX;
+                    int index = rowStart + localX;
+                    state.FactoryLayer.TryGetPayload(x, y, payloadChannel, out int payloadValue);
+                    state.ConveyorPayloadRead[index] = payloadValue;
+                    state.ConveyorPayloadWrite[index] = payloadValue;
+                    state.ConveyorIntentTargetBySource[index] = -1;
+                    state.ConveyorWinnerSourceByTarget[index] = -1;
+                    state.ConveyorWinningTargetBySource[index] = -1;
+                    state.ConveyorCanExecuteMoveBySource[index] = 0;
+                }
+            }
+
+            // Phase 1: intention collection + deterministic target arbitration.
+            // Each source can nominate at most one target.
+            // For targets with multiple nominations, smallest source index wins.
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = state.FactoryLayer.MinX + localX;
+                    int sourceIndex = rowStart + localX;
+
+                    if (state.ConveyorPayloadRead[sourceIndex] == 0)
+                    {
+                        continue;
+                    }
+
+                    if (!state.FactoryLayer.TryGet(x, y, out GridCellData sourceCell)
+                        || sourceCell.StateId != (int)GridStateId.Conveyor)
+                    {
+                        continue;
+                    }
+
+                    if (!TryGetConveyorTarget(x, y, sourceCell.VariantId, out int targetX, out int targetY))
+                    {
+                        continue;
+                    }
+
+                    if (!state.FactoryLayer.IsInRange(targetX, targetY)
+                        || !state.FactoryLayer.TryGet(targetX, targetY, out GridCellData targetCell)
+                        || targetCell.StateId != (int)GridStateId.Conveyor)
+                    {
+                        continue;
+                    }
+
+                    int targetLocalX = targetX - state.FactoryLayer.MinX;
+                    int targetLocalY = targetY - state.FactoryLayer.MinY;
+                    int targetIndex = (targetLocalY * width) + targetLocalX;
+
+                    state.ConveyorIntentTargetBySource[sourceIndex] = targetIndex;
+
+                    int existingWinner = state.ConveyorWinnerSourceByTarget[targetIndex];
+                    if (existingWinner < 0 || sourceIndex < existingWinner)
+                    {
+                        state.ConveyorWinnerSourceByTarget[targetIndex] = sourceIndex;
+                    }
+                }
+            }
+
+            // Build winner-only source->target mapping from arbitration output.
+            for (int targetIndex = 0; targetIndex < cellCount; targetIndex++)
+            {
+                int winningSource = state.ConveyorWinnerSourceByTarget[targetIndex];
+                if (winningSource >= 0 && state.ConveyorIntentTargetBySource[winningSource] == targetIndex)
+                {
+                    state.ConveyorWinningTargetBySource[winningSource] = targetIndex;
+                }
+            }
+
+            // Phase 2: execution-resolution propagation.
+            // Rule for winning source S -> target T:
+            // - executable immediately if T is empty in snapshot
+            // - otherwise executable only if T's own winning move executes
+            // This propagation enables same-tick continuous chain movement without relying on iteration artifacts.
+            PropagateExecutableMoves(ref state, cellCount);
+
+            // Detect unresolved occupied cycles and mark only cycle members executable.
+            // This allows loop rotation while still preserving true dead-end blocking.
+            int traversalStamp = 1;
+
+            for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+            {
+                if (state.ConveyorCanExecuteMoveBySource[sourceIndex] != 0)
+                {
+                    continue;
+                }
+
+                if (state.ConveyorWinningTargetBySource[sourceIndex] < 0)
+                {
+                    continue;
+                }
+
+                int current = sourceIndex;
+                while (true)
+                {
+                    if (state.ConveyorCanExecuteMoveBySource[current] != 0)
+                    {
+                        break;
+                    }
+
+                    int targetIndex = state.ConveyorWinningTargetBySource[current];
+                    if (targetIndex < 0)
+                    {
+                        break;
+                    }
+
+                    if (state.ConveyorPayloadRead[targetIndex] == 0)
+                    {
+                        break;
+                    }
+
+                    if (state.ConveyorWinningTargetBySource[targetIndex] < 0)
+                    {
+                        break;
+                    }
+
+                    if (state.ConveyorVisitStampBySource[current] == traversalStamp)
+                    {
+                        int cycleStart = current;
+                        int cycleNode = cycleStart;
+
+                        while (true)
+                        {
+                            state.ConveyorCanExecuteMoveBySource[cycleNode] = 1;
+                            cycleNode = state.ConveyorWinningTargetBySource[cycleNode];
+
+                            if (cycleNode == cycleStart)
+                            {
+                                break;
+                            }
+                        }
+
+                        break;
+                    }
+
+                    state.ConveyorVisitStampBySource[current] = traversalStamp;
+                    current = targetIndex;
+                }
+
+                traversalStamp++;
+            }
+
+            // Re-run propagation so predecessors of validated cycles become executable.
+            PropagateExecutableMoves(ref state, cellCount);
+
+            // Phase 3: commit executable moves to write-buffer, then flush to layer payload channel.
+            for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+            {
+                if (state.ConveyorCanExecuteMoveBySource[sourceIndex] == 0)
+                {
+                    continue;
+                }
+
+                int targetIndex = state.ConveyorWinningTargetBySource[sourceIndex];
+                if (targetIndex < 0)
+                {
+                    continue;
+                }
+
+                state.ConveyorPayloadWrite[sourceIndex] = 0;
+                state.ConveyorPayloadWrite[targetIndex] = state.ConveyorPayloadRead[sourceIndex];
+            }
+
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = state.FactoryLayer.MinX + localX;
+                    int index = rowStart + localX;
+                    state.FactoryLayer.TrySetPayload(x, y, payloadChannel, state.ConveyorPayloadWrite[index]);
+                }
+            }
+        }
+
+        private static void EnsureConveyorBuffers(ref MinimalFactoryGameState state, int cellCount)
+        {
+            if (state.ConveyorPayloadRead == null || state.ConveyorPayloadRead.Length != cellCount)
+            {
+                state.ConveyorPayloadRead = new int[cellCount];
+            }
+
+            if (state.ConveyorPayloadWrite == null || state.ConveyorPayloadWrite.Length != cellCount)
+            {
+                state.ConveyorPayloadWrite = new int[cellCount];
+            }
+
+            if (state.ConveyorIntentTargetBySource == null || state.ConveyorIntentTargetBySource.Length != cellCount)
+            {
+                state.ConveyorIntentTargetBySource = new int[cellCount];
+            }
+
+            if (state.ConveyorWinnerSourceByTarget == null || state.ConveyorWinnerSourceByTarget.Length != cellCount)
+            {
+                state.ConveyorWinnerSourceByTarget = new int[cellCount];
+            }
+
+            if (state.ConveyorWinningTargetBySource == null || state.ConveyorWinningTargetBySource.Length != cellCount)
+            {
+                state.ConveyorWinningTargetBySource = new int[cellCount];
+            }
+
+            if (state.ConveyorCanExecuteMoveBySource == null || state.ConveyorCanExecuteMoveBySource.Length != cellCount)
+            {
+                state.ConveyorCanExecuteMoveBySource = new byte[cellCount];
+            }
+
+            if (state.ConveyorVisitStampBySource == null || state.ConveyorVisitStampBySource.Length != cellCount)
+            {
+                state.ConveyorVisitStampBySource = new int[cellCount];
+            }
+
+        }
+
+        private static void PropagateExecutableMoves(ref MinimalFactoryGameState state, int cellCount)
+        {
+            bool changed = true;
+
+            while (changed)
+            {
+                changed = false;
+
+                for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+                {
+                    if (state.ConveyorCanExecuteMoveBySource[sourceIndex] != 0)
+                    {
+                        continue;
+                    }
+
+                    int targetIndex = state.ConveyorWinningTargetBySource[sourceIndex];
+                    if (targetIndex < 0)
+                    {
+                        continue;
+                    }
+
+                    if (state.ConveyorPayloadRead[targetIndex] == 0)
+                    {
+                        state.ConveyorCanExecuteMoveBySource[sourceIndex] = 1;
+                        changed = true;
+                        continue;
+                    }
+
+                    if (state.ConveyorWinningTargetBySource[targetIndex] >= 0
+                        && state.ConveyorCanExecuteMoveBySource[targetIndex] != 0)
+                    {
+                        state.ConveyorCanExecuteMoveBySource[sourceIndex] = 1;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        private static bool TryGetConveyorTarget(int x, int y, int variantId, out int targetX, out int targetY)
+        {
+            targetX = x;
+            targetY = y;
+
+            CellOrientation orientation = GridCellData.GetOrientationEnum(variantId);
+            switch (orientation)
+            {
+                case CellOrientation.Up:
+                    targetY = y - 1;
+                    return true;
+                case CellOrientation.Right:
+                    targetX = x + 1;
+                    return true;
+                case CellOrientation.Down:
+                    targetY = y + 1;
+                    return true;
+                case CellOrientation.Left:
+                    targetX = x - 1;
+                    return true;
+                default:
+                    return false;
             }
         }
 

--- a/Assets/Tests/EditMode/ConveyorPayloadMovementTests.cs
+++ b/Assets/Tests/EditMode/ConveyorPayloadMovementTests.cs
@@ -1,0 +1,132 @@
+using FactoryMustScale.Simulation;
+using NUnit.Framework;
+
+namespace FactoryMustScale.Tests.EditMode
+{
+    public sealed class ConveyorPayloadMovementTests
+    {
+        [Test]
+        public void ConveyorChain_ContinuousMovement_PropagatesWithinSameTick()
+        {
+            // Layout (all conveyors facing right):
+            // [0]=11, [1]=22, [2]=33, [3]=empty
+            // Expected after one tick (same-tick propagation):
+            // [0]=empty, [1]=11, [2]=22, [3]=33
+            var harness = CreateRunningHarness(width: 4, height: 1);
+
+            SetConveyor(harness.State.FactoryLayer, 0, 0, CellOrientation.Right);
+            SetConveyor(harness.State.FactoryLayer, 1, 0, CellOrientation.Right);
+            SetConveyor(harness.State.FactoryLayer, 2, 0, CellOrientation.Right);
+            SetConveyor(harness.State.FactoryLayer, 3, 0, CellOrientation.Right);
+
+            SetPayload(harness.State.FactoryLayer, 0, 0, 11);
+            SetPayload(harness.State.FactoryLayer, 1, 0, 22);
+            SetPayload(harness.State.FactoryLayer, 2, 0, 33);
+            SetPayload(harness.State.FactoryLayer, 3, 0, 0);
+
+            harness.Tick(1);
+
+            AssertPayload(harness.State.FactoryLayer, 0, 0, 0);
+            AssertPayload(harness.State.FactoryLayer, 1, 0, 11);
+            AssertPayload(harness.State.FactoryLayer, 2, 0, 22);
+            AssertPayload(harness.State.FactoryLayer, 3, 0, 33);
+        }
+
+        [Test]
+        public void ConveyorChain_BlockedDeadEnd_StopsEntireChainInSameTick()
+        {
+            // Layout (all conveyors facing right):
+            // [0]=11, [1]=22, [2]=33, [3]=44 (dead-end: last belt points out-of-range)
+            // Expected after one tick:
+            // no movement at all due to propagated blocking from the terminal belt.
+            var harness = CreateRunningHarness(width: 4, height: 1);
+
+            SetConveyor(harness.State.FactoryLayer, 0, 0, CellOrientation.Right);
+            SetConveyor(harness.State.FactoryLayer, 1, 0, CellOrientation.Right);
+            SetConveyor(harness.State.FactoryLayer, 2, 0, CellOrientation.Right);
+            SetConveyor(harness.State.FactoryLayer, 3, 0, CellOrientation.Right);
+
+            SetPayload(harness.State.FactoryLayer, 0, 0, 11);
+            SetPayload(harness.State.FactoryLayer, 1, 0, 22);
+            SetPayload(harness.State.FactoryLayer, 2, 0, 33);
+            SetPayload(harness.State.FactoryLayer, 3, 0, 44);
+
+            harness.Tick(1);
+
+            AssertPayload(harness.State.FactoryLayer, 0, 0, 11);
+            AssertPayload(harness.State.FactoryLayer, 1, 0, 22);
+            AssertPayload(harness.State.FactoryLayer, 2, 0, 33);
+            AssertPayload(harness.State.FactoryLayer, 3, 0, 44);
+        }
+
+        [Test]
+        public void ConveyorConflict_TwoSourcesOneTarget_UsesLowestSourceIndex()
+        {
+            // Grid indexes on width=3:
+            // y=0: [0][1][2]
+            // y=1: [3][4][5]
+            // source A: index 1 (1,0) Down -> target index 4 (1,1)
+            // source B: index 3 (0,1) Right -> target index 4 (1,1)
+            // Winner should be index 1 (lower source index).
+            var harness = CreateRunningHarness(width: 3, height: 2);
+
+            SetConveyor(harness.State.FactoryLayer, 1, 0, CellOrientation.Down);
+            SetConveyor(harness.State.FactoryLayer, 0, 1, CellOrientation.Right);
+            SetConveyor(harness.State.FactoryLayer, 1, 1, CellOrientation.Right);
+
+            SetPayload(harness.State.FactoryLayer, 1, 0, 101);
+            SetPayload(harness.State.FactoryLayer, 0, 1, 202);
+            SetPayload(harness.State.FactoryLayer, 1, 1, 0);
+
+            harness.Tick(1);
+
+            AssertPayload(harness.State.FactoryLayer, 1, 0, 0);
+            AssertPayload(harness.State.FactoryLayer, 0, 1, 202);
+            AssertPayload(harness.State.FactoryLayer, 1, 1, 101);
+        }
+
+        private static FixedStepSimulationHarness<MinimalFactoryGameState, MinimalFactoryGameLoopSystem> CreateRunningHarness(int width, int height)
+        {
+            var state = new MinimalFactoryGameState
+            {
+                Seed = 0,
+                TerrainResourceChannelIndex = 0,
+                FactoryPayloadItemChannelIndex = 0,
+                MaxFactoryTicks = 128,
+                FactoryTicksExecuted = 0,
+                Phase = MinimalFactoryGamePhase.Running,
+                TerrainLayer = new Layer(0, 0, width, height, payloadChannelCount: 1),
+                FactoryLayer = new Layer(0, 0, width, height, payloadChannelCount: 1),
+                CommandQueue = new FactoryCommandQueue(capacity: 8),
+                CommandResults = new FactoryCommandResultBuffer(capacity: 8),
+                BuildableRules = new BuildableRuleData[0],
+                Footprints = new FactoryFootprintData[0],
+                StopProcessingOnFailure = false,
+            };
+
+            return new FixedStepSimulationHarness<MinimalFactoryGameState, MinimalFactoryGameLoopSystem>(
+                state,
+                new MinimalFactoryGameLoopSystem());
+        }
+
+        private static void SetConveyor(Layer layer, int x, int y, CellOrientation orientation)
+        {
+            int variantId = GridCellData.SetOrientation(0, orientation);
+            bool placed = layer.TrySetCellState(x, y, (int)GridStateId.Conveyor, variantId, 0u, currentTick: 0, out _);
+            Assert.That(placed, Is.True);
+        }
+
+        private static void SetPayload(Layer layer, int x, int y, int payload)
+        {
+            bool set = layer.TrySetPayload(x, y, channelIndex: 0, payloadValue: payload);
+            Assert.That(set, Is.True);
+        }
+
+        private static void AssertPayload(Layer layer, int x, int y, int expected)
+        {
+            bool found = layer.TryGetPayload(x, y, channelIndex: 0, out int value);
+            Assert.That(found, Is.True);
+            Assert.That(value, Is.EqualTo(expected));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/FactoryCellProcessDefinitionTests.cs
+++ b/Assets/Tests/EditMode/FactoryCellProcessDefinitionTests.cs
@@ -1,0 +1,158 @@
+using System.Reflection;
+using FactoryMustScale.Authoring;
+using FactoryMustScale.Simulation;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FactoryMustScale.Tests.EditMode
+{
+    public sealed class FactoryCellProcessDefinitionTests
+    {
+        [Test]
+        public void BakeToRuntimeData_MapsDefinitionFields_AndUsesFixedRecipeDimensions()
+        {
+            var definition = ScriptableObject.CreateInstance<FactoryCellProcessDefinition>();
+
+            SetPrivateField(definition, "_stateId", GridStateId.CrafterCore);
+            SetPrivateField(definition, "_processType", FactoryProcessType.Craft);
+            SetPrivateField(definition, "_processDurationTicks", 6);
+            SetPrivateField(definition, "_processProgressPayloadChannelIndex", 3);
+            SetPrivateField(definition, "_inputSlots", new[]
+            {
+                new FactoryProcessSlotDefinition
+                {
+                    Directions = CardinalDirectionMask.Left,
+                    ItemIdFilter = 101,
+                    MaxItemsPerTick = 2,
+                }
+            });
+            SetPrivateField(definition, "_outputSlots", new[]
+            {
+                new FactoryProcessSlotDefinition
+                {
+                    Directions = CardinalDirectionMask.Right,
+                    ItemIdFilter = 0,
+                    MaxItemsPerTick = 1,
+                }
+            });
+            SetPrivateField(definition, "_recipes", new[]
+            {
+                new FactoryProcessRecipeDefinition
+                {
+                    ItemInputs = new[]
+                    {
+                        new ProcessItemStackDefinition { ItemId = 101, Amount = 2 },
+                        new ProcessItemStackDefinition { ItemId = 102, Amount = 1 },
+                    },
+                    ItemOutputs = new[]
+                    {
+                        new ProcessItemStackDefinition { ItemId = 201, Amount = 1 },
+                    },
+                    ResourceDeltas = new[]
+                    {
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.ElectricPower, Amount = -5 },
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.Heat, Amount = 2 },
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.MechanicalWork, Amount = -1 },
+                    },
+                }
+            });
+
+            FactoryCellProcessData runtime = definition.BakeToRuntimeData();
+
+            Assert.That(runtime.StateId, Is.EqualTo((int)GridStateId.CrafterCore));
+            Assert.That(runtime.ProcessType, Is.EqualTo(FactoryProcessType.Craft));
+            Assert.That(runtime.ProcessDurationTicks, Is.EqualTo(6));
+            Assert.That(runtime.ProcessProgressPayloadChannelIndex, Is.EqualTo(3));
+            Assert.That(runtime.InputSlots.Length, Is.EqualTo(1));
+            Assert.That(runtime.OutputSlots.Length, Is.EqualTo(1));
+            Assert.That(runtime.Recipes.Length, Is.EqualTo(1));
+            Assert.That(runtime.InputSlots[0].Directions, Is.EqualTo(CardinalDirectionMask.Left));
+            Assert.That(runtime.OutputSlots[0].Directions, Is.EqualTo(CardinalDirectionMask.Right));
+
+            Assert.That(runtime.Recipes[0].ItemInputs.Length, Is.EqualTo(FactoryProcessRecipeData.ItemInputCount));
+            Assert.That(runtime.Recipes[0].ItemOutputs.Length, Is.EqualTo(FactoryProcessRecipeData.ItemOutputCount));
+            Assert.That(runtime.Recipes[0].ResourceDeltas.Length, Is.EqualTo(FactoryProcessRecipeData.ResourceDeltaCount));
+
+            Assert.That(runtime.Recipes[0].ItemInputs[0].ItemId, Is.EqualTo(101));
+            Assert.That(runtime.Recipes[0].ItemInputs[1].ItemId, Is.EqualTo(102));
+            Assert.That(runtime.Recipes[0].ItemInputs[2].ItemId, Is.EqualTo(0));
+
+            Assert.That(runtime.Recipes[0].ItemOutputs[0].ItemId, Is.EqualTo(201));
+            Assert.That(runtime.Recipes[0].ItemOutputs[1].ItemId, Is.EqualTo(0));
+
+            Assert.That(runtime.Recipes[0].ResourceDeltas[0].ResourceType, Is.EqualTo(ProcessResourceType.ElectricPower));
+            Assert.That(runtime.Recipes[0].ResourceDeltas[1].ResourceType, Is.EqualTo(ProcessResourceType.Heat));
+            Assert.That(runtime.Recipes[0].ResourceDeltas[2].ResourceType, Is.EqualTo(ProcessResourceType.MechanicalWork));
+            Assert.That(runtime.Recipes[0].ResourceDeltas[3].ResourceType, Is.EqualTo(ProcessResourceType.None));
+
+            Object.DestroyImmediate(definition);
+        }
+
+        [Test]
+        public void BakeToRuntimeData_TruncatesExcessRecipeEntriesToFixedDimensions()
+        {
+            var definition = ScriptableObject.CreateInstance<FactoryCellProcessDefinition>();
+
+            SetPrivateField(definition, "_recipes", new[]
+            {
+                new FactoryProcessRecipeDefinition
+                {
+                    ItemInputs = new[]
+                    {
+                        new ProcessItemStackDefinition { ItemId = 1, Amount = 1 },
+                        new ProcessItemStackDefinition { ItemId = 2, Amount = 1 },
+                        new ProcessItemStackDefinition { ItemId = 3, Amount = 1 },
+                        new ProcessItemStackDefinition { ItemId = 4, Amount = 1 },
+                    },
+                    ItemOutputs = new[]
+                    {
+                        new ProcessItemStackDefinition { ItemId = 10, Amount = 1 },
+                        new ProcessItemStackDefinition { ItemId = 11, Amount = 1 },
+                        new ProcessItemStackDefinition { ItemId = 12, Amount = 1 },
+                    },
+                    ResourceDeltas = new[]
+                    {
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.ElectricPower, Amount = 1 },
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.Heat, Amount = 1 },
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.MechanicalWork, Amount = 1 },
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.Reserved, Amount = 1 },
+                        new ProcessResourceDeltaDefinition { ResourceType = ProcessResourceType.ElectricPower, Amount = 99 },
+                    },
+                }
+            });
+
+            FactoryCellProcessData runtime = definition.BakeToRuntimeData();
+
+            Assert.That(runtime.Recipes[0].ItemInputs.Length, Is.EqualTo(3));
+            Assert.That(runtime.Recipes[0].ItemInputs[2].ItemId, Is.EqualTo(3));
+
+            Assert.That(runtime.Recipes[0].ItemOutputs.Length, Is.EqualTo(2));
+            Assert.That(runtime.Recipes[0].ItemOutputs[1].ItemId, Is.EqualTo(11));
+
+            Assert.That(runtime.Recipes[0].ResourceDeltas.Length, Is.EqualTo(4));
+            Assert.That(runtime.Recipes[0].ResourceDeltas[3].ResourceType, Is.EqualTo(ProcessResourceType.Reserved));
+
+            Object.DestroyImmediate(definition);
+        }
+
+        [Test]
+        public void GridCellData_ProcessProfileId_RoundTripsInVariantCodeBits()
+        {
+            int variantId = 0;
+            variantId = GridCellData.SetProcessProfileId(variantId, processProfileId: 55);
+
+            Assert.That(GridCellData.GetProcessProfileId(variantId), Is.EqualTo(55));
+
+            variantId = GridCellData.SetOrientation(variantId, CellOrientation.Left);
+            Assert.That(GridCellData.GetOrientationEnum(variantId), Is.EqualTo(CellOrientation.Left));
+            Assert.That(GridCellData.GetProcessProfileId(variantId), Is.EqualTo(55));
+        }
+
+        private static void SetPrivateField<TValue>(object target, string fieldName, TValue value)
+        {
+            FieldInfo field = target.GetType().GetField(fieldName, BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.That(field, Is.Not.Null, $"Missing field: {fieldName}");
+            field.SetValue(target, value);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Authoring requested deterministic fixed-size recipe arrays so designers can rely on exact dimensions (allow stacking "separation" recipes), specifically 2 item outputs and 4 resource delta slots with one reserved slot for future use. 
- The simulation schema must remain deterministic and allocation-free in hot paths, so baking SOs to plain fixed-size runtime arrays is required. 
- Also clarify process profile packing into `VariantCode` bits so placed cells map to baked process definitions while dynamic counters remain in payload channels.

### Description
- Added typed resource support and fixed-size recipe layout by introducing `ProcessResourceType`, `ProcessItemStackData`, `ProcessResourceDeltaData`, and `FactoryProcessRecipeData` with constants `ItemInputCount = 3`, `ItemOutputCount = 2`, and `ResourceDeltaCount = 4` in `Assets/Scripts/Simulation/FactoryCellProcessData.cs`.
- Reworked authoring `FactoryCellProcessDefinition` (`Assets/Scripts/Authoring/FactoryCellProcessDefinition.cs`) to expose array-based recipe authoring and deterministic baking via `BakeToRuntimeData()`, which pads with defaults or truncates to the fixed dimensions (no runtime allocations in the bake result beyond the arrays themselves).
- Added packing helpers to `GridCellData` to read/write a process profile id into the `VariantCode` bits via `GetProcessProfileId`/`SetProcessProfileId`, and documented that dynamic progress counters belong in payload channels (`Assets/Scripts/Simulation/GridCellData.cs`).
- Implemented an allocation-free deterministic conveyor payload movement phase in `MinimalFactoryGameLoopSystem` with preallocated scratch buffers and explicit 3-phase resolution (`Assets/Scripts/Simulation/MinimalFactoryGameLoop.cs`), and added `ConveyorPayloadMovementTests` (`Assets/Tests/EditMode/ConveyorPayloadMovementTests.cs`) to validate chain movement, dead-end blocking, and conflict arbitration.
- Updated and expanded EditMode tests for process baking to verify padding and truncation behavior (`Assets/Tests/EditMode/FactoryCellProcessDefinitionTests.cs`).

### Testing
- Ran `git diff --check` which completed without issues.
- Attempted `dotnet test` but it could not run in this environment because `dotnet` is not installed (run tests in Unity Editor locally to execute EditMode tests).
- New EditMode tests to run in the Unity Editor are `FactoryCellProcessDefinitionTests.BakeToRuntimeData_MapsDefinitionFields_AndUsesFixedRecipeDimensions`, `FactoryCellProcessDefinitionTests.BakeToRuntimeData_TruncatesExcessRecipeEntriesToFixedDimensions`, `FactoryCellProcessDefinitionTests.GridCellData_ProcessProfileId_RoundTripsInVariantCodeBits`, and the conveyor tests in `ConveyorPayloadMovementTests`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d6dbe216c832798a500c16ce05fce)