### PR TITLE
Add core item simulation phase with pluggable conveyor transport algorithms

### DIFF
--- a/Assets/Scripts/Simulation/Core/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/Simulation/Core/FactoryCoreLoopSystem.cs
@@ -1,5 +1,7 @@
 namespace FactoryMustScale.Simulation.Core
 {
+    using FactoryMustScale.Simulation.Item;
+
     /// <summary>
     /// Authoritative factory tick step order.
     ///
@@ -40,6 +42,20 @@ namespace FactoryMustScale.Simulation.Core
         // Optional preallocated trace buffer.
         public int[] PhaseTraceBuffer;
         public int PhaseTraceCount;
+
+        // Item simulation inputs.
+        public Layer FactoryLayer;
+        public int FactoryPayloadItemChannelIndex;
+        public ItemTransportAlgorithm ItemTransportAlgorithm;
+
+        // Item transport scratch buffers (reused, no hot-path allocations).
+        public int[] ItemPayloadRead;
+        public int[] ItemPayloadWrite;
+        public int[] ItemIntentTargetBySource;
+        public int[] ItemWinnerSourceByTarget;
+        public int[] ItemWinningTargetBySource;
+        public byte[] ItemCanExecuteMoveBySource;
+        public int[] ItemVisitStampBySource;
     }
 
     /// <summary>
@@ -101,6 +117,7 @@ namespace FactoryMustScale.Simulation.Core
         private static void RunSimulation(ref FactoryCoreLoopState state, int tickIndex)
         {
             state.RunSimulationCount++;
+            ItemTransportPhaseSystem.Run(ref state);
             AppendTrace(ref state, FactoryTickStep.RunSimulation, tickIndex);
         }
 

--- a/Assets/Scripts/Simulation/Item/ConveyorArbitratedPropagationSystem.cs
+++ b/Assets/Scripts/Simulation/Item/ConveyorArbitratedPropagationSystem.cs
@@ -1,0 +1,313 @@
+namespace FactoryMustScale.Simulation.Item
+{
+    using FactoryMustScale.Simulation.Core;
+
+    /// <summary>
+    /// Deterministic conveyor payload movement with source-target arbitration and same-tick propagation.
+    /// </summary>
+    public static class ConveyorArbitratedPropagationSystem
+    {
+        private const int DefaultFactoryPayloadItemChannel = 0;
+
+        public static void Run(ref FactoryCoreLoopState state)
+        {
+            int payloadChannel = state.FactoryPayloadItemChannelIndex;
+            if (payloadChannel < 0)
+            {
+                payloadChannel = DefaultFactoryPayloadItemChannel;
+            }
+
+            if (state.FactoryLayer == null || payloadChannel >= state.FactoryLayer.PayloadChannelCount)
+            {
+                return;
+            }
+
+            int width = state.FactoryLayer.Width;
+            int height = state.FactoryLayer.Height;
+            int cellCount = width * height;
+
+            EnsureBuffers(ref state, cellCount);
+
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = state.FactoryLayer.MinX + localX;
+                    int sourceIndex = rowStart + localX;
+
+                    state.FactoryLayer.TryGetPayload(x, y, payloadChannel, out int payloadValue);
+                    state.ItemPayloadRead[sourceIndex] = payloadValue;
+                    state.ItemPayloadWrite[sourceIndex] = payloadValue;
+                    state.ItemIntentTargetBySource[sourceIndex] = -1;
+                    state.ItemWinnerSourceByTarget[sourceIndex] = -1;
+                    state.ItemWinningTargetBySource[sourceIndex] = -1;
+                    state.ItemCanExecuteMoveBySource[sourceIndex] = 0;
+                }
+            }
+
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = state.FactoryLayer.MinX + localX;
+                    int sourceIndex = rowStart + localX;
+
+                    if (state.ItemPayloadRead[sourceIndex] == 0)
+                    {
+                        continue;
+                    }
+
+                    if (!state.FactoryLayer.TryGet(x, y, out GridCellData sourceCell)
+                        || sourceCell.StateId != (int)GridStateId.Conveyor)
+                    {
+                        continue;
+                    }
+
+                    if (!TryGetConveyorTarget(x, y, sourceCell.VariantId, out int targetX, out int targetY))
+                    {
+                        continue;
+                    }
+
+                    if (!state.FactoryLayer.IsInRange(targetX, targetY)
+                        || !state.FactoryLayer.TryGet(targetX, targetY, out GridCellData targetCell)
+                        || targetCell.StateId != (int)GridStateId.Conveyor)
+                    {
+                        continue;
+                    }
+
+                    int targetLocalX = targetX - state.FactoryLayer.MinX;
+                    int targetLocalY = targetY - state.FactoryLayer.MinY;
+                    int targetIndex = (targetLocalY * width) + targetLocalX;
+
+                    state.ItemIntentTargetBySource[sourceIndex] = targetIndex;
+
+                    int existingWinner = state.ItemWinnerSourceByTarget[targetIndex];
+                    if (existingWinner < 0 || sourceIndex < existingWinner)
+                    {
+                        state.ItemWinnerSourceByTarget[targetIndex] = sourceIndex;
+                    }
+                }
+            }
+
+            for (int targetIndex = 0; targetIndex < cellCount; targetIndex++)
+            {
+                int winningSource = state.ItemWinnerSourceByTarget[targetIndex];
+                if (winningSource >= 0 && state.ItemIntentTargetBySource[winningSource] == targetIndex)
+                {
+                    state.ItemWinningTargetBySource[winningSource] = targetIndex;
+                }
+            }
+
+            PropagateExecutableMoves(ref state, cellCount);
+
+            int traversalStamp = 1;
+            for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+            {
+                if (state.ItemCanExecuteMoveBySource[sourceIndex] != 0)
+                {
+                    continue;
+                }
+
+                if (state.ItemWinningTargetBySource[sourceIndex] < 0)
+                {
+                    continue;
+                }
+
+                int current = sourceIndex;
+                while (true)
+                {
+                    if (state.ItemCanExecuteMoveBySource[current] != 0)
+                    {
+                        break;
+                    }
+
+                    int targetIndex = state.ItemWinningTargetBySource[current];
+                    if (targetIndex < 0)
+                    {
+                        break;
+                    }
+
+                    if (state.ItemPayloadRead[targetIndex] == 0)
+                    {
+                        break;
+                    }
+
+                    if (state.ItemWinningTargetBySource[targetIndex] < 0)
+                    {
+                        break;
+                    }
+
+                    if (state.ItemVisitStampBySource[current] == traversalStamp)
+                    {
+                        int cycleStart = current;
+                        int cycleNode = cycleStart;
+
+                        while (true)
+                        {
+                            state.ItemCanExecuteMoveBySource[cycleNode] = 1;
+                            cycleNode = state.ItemWinningTargetBySource[cycleNode];
+
+                            if (cycleNode == cycleStart)
+                            {
+                                break;
+                            }
+                        }
+
+                        break;
+                    }
+
+                    state.ItemVisitStampBySource[current] = traversalStamp;
+                    current = targetIndex;
+                }
+
+                traversalStamp++;
+            }
+
+            PropagateExecutableMoves(ref state, cellCount);
+
+            // Commit in two passes to avoid chain-overwrite bugs.
+            for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+            {
+                if (state.ItemCanExecuteMoveBySource[sourceIndex] != 0)
+                {
+                    state.ItemPayloadWrite[sourceIndex] = 0;
+                }
+            }
+
+            for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+            {
+                if (state.ItemCanExecuteMoveBySource[sourceIndex] == 0)
+                {
+                    continue;
+                }
+
+                int targetIndex = state.ItemWinningTargetBySource[sourceIndex];
+                if (targetIndex < 0)
+                {
+                    continue;
+                }
+
+                state.ItemPayloadWrite[targetIndex] = state.ItemPayloadRead[sourceIndex];
+            }
+
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = state.FactoryLayer.MinX + localX;
+                    int index = rowStart + localX;
+                    state.FactoryLayer.TrySetPayload(x, y, payloadChannel, state.ItemPayloadWrite[index]);
+                }
+            }
+        }
+
+        private static void EnsureBuffers(ref FactoryCoreLoopState state, int cellCount)
+        {
+            if (state.ItemPayloadRead == null || state.ItemPayloadRead.Length != cellCount)
+            {
+                state.ItemPayloadRead = new int[cellCount];
+            }
+
+            if (state.ItemPayloadWrite == null || state.ItemPayloadWrite.Length != cellCount)
+            {
+                state.ItemPayloadWrite = new int[cellCount];
+            }
+
+            if (state.ItemIntentTargetBySource == null || state.ItemIntentTargetBySource.Length != cellCount)
+            {
+                state.ItemIntentTargetBySource = new int[cellCount];
+            }
+
+            if (state.ItemWinnerSourceByTarget == null || state.ItemWinnerSourceByTarget.Length != cellCount)
+            {
+                state.ItemWinnerSourceByTarget = new int[cellCount];
+            }
+
+            if (state.ItemWinningTargetBySource == null || state.ItemWinningTargetBySource.Length != cellCount)
+            {
+                state.ItemWinningTargetBySource = new int[cellCount];
+            }
+
+            if (state.ItemCanExecuteMoveBySource == null || state.ItemCanExecuteMoveBySource.Length != cellCount)
+            {
+                state.ItemCanExecuteMoveBySource = new byte[cellCount];
+            }
+
+            if (state.ItemVisitStampBySource == null || state.ItemVisitStampBySource.Length != cellCount)
+            {
+                state.ItemVisitStampBySource = new int[cellCount];
+            }
+        }
+
+        private static void PropagateExecutableMoves(ref FactoryCoreLoopState state, int cellCount)
+        {
+            bool changed = true;
+            while (changed)
+            {
+                changed = false;
+
+                for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+                {
+                    if (state.ItemCanExecuteMoveBySource[sourceIndex] != 0)
+                    {
+                        continue;
+                    }
+
+                    int targetIndex = state.ItemWinningTargetBySource[sourceIndex];
+                    if (targetIndex < 0)
+                    {
+                        continue;
+                    }
+
+                    if (state.ItemPayloadRead[targetIndex] == 0)
+                    {
+                        state.ItemCanExecuteMoveBySource[sourceIndex] = 1;
+                        changed = true;
+                        continue;
+                    }
+
+                    if (state.ItemWinningTargetBySource[targetIndex] >= 0
+                        && state.ItemCanExecuteMoveBySource[targetIndex] != 0)
+                    {
+                        state.ItemCanExecuteMoveBySource[sourceIndex] = 1;
+                        changed = true;
+                    }
+                }
+            }
+        }
+
+        private static bool TryGetConveyorTarget(int x, int y, int variantId, out int targetX, out int targetY)
+        {
+            targetX = x;
+            targetY = y;
+
+            CellOrientation orientation = GridCellData.GetOrientationEnum(variantId);
+            switch (orientation)
+            {
+                case CellOrientation.Up:
+                    targetY = y - 1;
+                    return true;
+                case CellOrientation.Right:
+                    targetX = x + 1;
+                    return true;
+                case CellOrientation.Down:
+                    targetY = y + 1;
+                    return true;
+                case CellOrientation.Left:
+                    targetX = x - 1;
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/Item/ConveyorGraphBasedExperimentalSystem.cs
+++ b/Assets/Scripts/Simulation/Item/ConveyorGraphBasedExperimentalSystem.cs
@@ -3,9 +3,9 @@ namespace FactoryMustScale.Simulation.Item
     using FactoryMustScale.Simulation.Core;
 
     /// <summary>
-    /// Placeholder for a future graph-based conveyor item simulation (Mindustry-style).
+    /// Placeholder for a future graph-based conveyor item simulation (graph-based).
     /// </summary>
-    public static class ConveyorMindustryGraphSystem
+    public static class ConveyorGraphBasedExperimentalSystem
     {
         public static void Run(ref FactoryCoreLoopState state)
         {

--- a/Assets/Scripts/Simulation/Item/ConveyorMindustryGraphSystem.cs
+++ b/Assets/Scripts/Simulation/Item/ConveyorMindustryGraphSystem.cs
@@ -1,0 +1,15 @@
+namespace FactoryMustScale.Simulation.Item
+{
+    using FactoryMustScale.Simulation.Core;
+
+    /// <summary>
+    /// Placeholder for a future graph-based conveyor item simulation (Mindustry-style).
+    /// </summary>
+    public static class ConveyorMindustryGraphSystem
+    {
+        public static void Run(ref FactoryCoreLoopState state)
+        {
+            // Intentionally no-op for now. Algorithm hook exists for future benchmarking and comparison.
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/Item/ItemTransportAlgorithm.cs
+++ b/Assets/Scripts/Simulation/Item/ItemTransportAlgorithm.cs
@@ -1,0 +1,12 @@
+namespace FactoryMustScale.Simulation.Item
+{
+    /// <summary>
+    /// Selects which deterministic item transport implementation runs during the core simulation phase.
+    /// </summary>
+    public enum ItemTransportAlgorithm : byte
+    {
+        None = 0,
+        ConveyorArbitratedPropagationV1 = 1,
+        ConveyorMindustryGraphExperimental = 2,
+    }
+}

--- a/Assets/Scripts/Simulation/Item/ItemTransportAlgorithm.cs
+++ b/Assets/Scripts/Simulation/Item/ItemTransportAlgorithm.cs
@@ -7,6 +7,6 @@ namespace FactoryMustScale.Simulation.Item
     {
         None = 0,
         ConveyorArbitratedPropagationV1 = 1,
-        ConveyorMindustryGraphExperimental = 2,
+        ConveyorGraphBasedExperimental = 2,
     }
 }

--- a/Assets/Scripts/Simulation/Item/ItemTransportPhaseSystem.cs
+++ b/Assets/Scripts/Simulation/Item/ItemTransportPhaseSystem.cs
@@ -1,0 +1,27 @@
+namespace FactoryMustScale.Simulation.Item
+{
+    using FactoryMustScale.Simulation.Core;
+
+    /// <summary>
+    /// Item-domain simulation entry point for FactoryCoreLoopSystem.RunSimulation.
+    /// </summary>
+    public static class ItemTransportPhaseSystem
+    {
+        public static void Run(ref FactoryCoreLoopState state)
+        {
+            switch (state.ItemTransportAlgorithm)
+            {
+                case ItemTransportAlgorithm.None:
+                    return;
+                case ItemTransportAlgorithm.ConveyorArbitratedPropagationV1:
+                    ConveyorArbitratedPropagationSystem.Run(ref state);
+                    return;
+                case ItemTransportAlgorithm.ConveyorMindustryGraphExperimental:
+                    ConveyorMindustryGraphSystem.Run(ref state);
+                    return;
+                default:
+                    return;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/Item/ItemTransportPhaseSystem.cs
+++ b/Assets/Scripts/Simulation/Item/ItemTransportPhaseSystem.cs
@@ -16,8 +16,8 @@ namespace FactoryMustScale.Simulation.Item
                 case ItemTransportAlgorithm.ConveyorArbitratedPropagationV1:
                     ConveyorArbitratedPropagationSystem.Run(ref state);
                     return;
-                case ItemTransportAlgorithm.ConveyorMindustryGraphExperimental:
-                    ConveyorMindustryGraphSystem.Run(ref state);
+                case ItemTransportAlgorithm.ConveyorGraphBasedExperimental:
+                    ConveyorGraphBasedExperimentalSystem.Run(ref state);
                     return;
                 default:
                     return;

--- a/Assets/Tests/EditMode/Core/FactoryCoreItemTransportTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryCoreItemTransportTests.cs
@@ -1,0 +1,99 @@
+using FactoryMustScale.Simulation;
+using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Item;
+using NUnit.Framework;
+
+namespace FactoryMustScale.Tests.EditMode.Core
+{
+    public sealed class FactoryCoreItemTransportTests
+    {
+        [Test]
+        public void ConveyorArbitratedPropagation_ChainPropagatesWithinSameTick()
+        {
+            FactoryCoreLoopState initialState = CreateState(width: 4, height: 1, ItemTransportAlgorithm.ConveyorArbitratedPropagationV1);
+
+            SetConveyor(initialState.FactoryLayer, 0, 0, CellOrientation.Right);
+            SetConveyor(initialState.FactoryLayer, 1, 0, CellOrientation.Right);
+            SetConveyor(initialState.FactoryLayer, 2, 0, CellOrientation.Right);
+            SetConveyor(initialState.FactoryLayer, 3, 0, CellOrientation.Right);
+
+            SetPayload(initialState.FactoryLayer, 0, 0, 11);
+            SetPayload(initialState.FactoryLayer, 1, 0, 22);
+            SetPayload(initialState.FactoryLayer, 2, 0, 33);
+            SetPayload(initialState.FactoryLayer, 3, 0, 0);
+
+            var harness = new FixedStepSimulationHarness<FactoryCoreLoopState, FactoryCoreLoopSystem>(
+                initialState,
+                new FactoryCoreLoopSystem());
+
+            harness.Tick(1);
+
+            AssertPayload(harness.State.FactoryLayer, 0, 0, 0);
+            AssertPayload(harness.State.FactoryLayer, 1, 0, 11);
+            AssertPayload(harness.State.FactoryLayer, 2, 0, 22);
+            AssertPayload(harness.State.FactoryLayer, 3, 0, 33);
+        }
+
+        [Test]
+        public void ConveyorArbitratedPropagation_BlockedDeadEndStopsChain()
+        {
+            FactoryCoreLoopState initialState = CreateState(width: 4, height: 1, ItemTransportAlgorithm.ConveyorArbitratedPropagationV1);
+
+            SetConveyor(initialState.FactoryLayer, 0, 0, CellOrientation.Right);
+            SetConveyor(initialState.FactoryLayer, 1, 0, CellOrientation.Right);
+            SetConveyor(initialState.FactoryLayer, 2, 0, CellOrientation.Right);
+            SetConveyor(initialState.FactoryLayer, 3, 0, CellOrientation.Right);
+
+            SetPayload(initialState.FactoryLayer, 0, 0, 11);
+            SetPayload(initialState.FactoryLayer, 1, 0, 22);
+            SetPayload(initialState.FactoryLayer, 2, 0, 33);
+            SetPayload(initialState.FactoryLayer, 3, 0, 44);
+
+            var harness = new FixedStepSimulationHarness<FactoryCoreLoopState, FactoryCoreLoopSystem>(
+                initialState,
+                new FactoryCoreLoopSystem());
+
+            harness.Tick(1);
+
+            AssertPayload(harness.State.FactoryLayer, 0, 0, 11);
+            AssertPayload(harness.State.FactoryLayer, 1, 0, 22);
+            AssertPayload(harness.State.FactoryLayer, 2, 0, 33);
+            AssertPayload(harness.State.FactoryLayer, 3, 0, 44);
+        }
+
+        private static FactoryCoreLoopState CreateState(int width, int height, ItemTransportAlgorithm algorithm)
+        {
+            return new FactoryCoreLoopState
+            {
+                Running = true,
+                MaxFactoryTicks = 8,
+                FactoryTicksExecuted = 0,
+                FactoryPayloadItemChannelIndex = 0,
+                ItemTransportAlgorithm = algorithm,
+                FactoryLayer = new Layer(0, 0, width, height, payloadChannelCount: 1),
+                PhaseTraceBuffer = new int[16],
+                PhaseTraceCount = 0,
+            };
+        }
+
+        private static void SetConveyor(Layer layer, int x, int y, CellOrientation orientation)
+        {
+            int variantId = GridCellData.SetOrientation(0, orientation);
+            bool placed = layer.TrySetCellState(x, y, (int)GridStateId.Conveyor, variantId, 0u, currentTick: 0, out _);
+            Assert.That(placed, Is.True);
+        }
+
+        private static void SetPayload(Layer layer, int x, int y, int payload)
+        {
+            bool set = layer.TrySetPayload(x, y, channelIndex: 0, payloadValue: payload);
+            Assert.That(set, Is.True);
+        }
+
+        private static void AssertPayload(Layer layer, int x, int y, int expected)
+        {
+            bool found = layer.TryGetPayload(x, y, channelIndex: 0, out int value);
+            Assert.That(found, Is.True);
+            Assert.That(value, Is.EqualTo(expected));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Move conveyor-item movement out of legacy scaffolding and into the new deterministic core loop so real factory item simulation can run from `FactoryCoreLoopSystem`. 
- Provide a pluggable algorithm surface so different conveyor algorithms (including a future Mindustry-style graph) can be swapped and benchmarked without changing core loop ordering.

### Description
- Wire item-domain execution into `FactoryCoreLoopSystem.RunSimulation` by calling `ItemTransportPhaseSystem.Run(ref state)` and extend `FactoryCoreLoopState` with `FactoryLayer`, `FactoryPayloadItemChannelIndex`, `ItemTransportAlgorithm`, and reusable item transport scratch buffers. 
- Add new `Simulation.Item` namespace with `ItemTransportAlgorithm` enum, `ItemTransportPhaseSystem` dispatcher, a placeholder `ConveyorMindustryGraphSystem` hook, and a deterministic implementation `ConveyorArbitratedPropagationSystem` that performs intent arbitration, same-tick propagation (including cycle handling), and a two-pass commit to avoid chain-overwrite. 
- Add EditMode tests `Assets/Tests/EditMode/Core/FactoryCoreItemTransportTests.cs` covering same-tick chain propagation and blocked-dead-end behavior driven through `FactoryCoreLoopSystem`. 
- Known limitations and next steps: `ConveyorMindustryGraphSystem` is currently a no-op placeholder; the PR does not yet migrate all legacy responsibilities into core systems, and next steps are to implement/benchmark a graph algorithm and add larger deterministic perf tests.

### Testing
- Added deterministic EditMode tests `FactoryMustScale.Tests.EditMode.Core.FactoryCoreItemTransportTests` (new) to validate propagation and blocking behavior under `FactoryCoreLoopSystem`. 
- Attempted to run the test runner via `dotnet test`, but execution failed in this environment because `dotnet` is not installed, so tests were not executed here. 
- Ran repository checks `git diff --check` and `git status` which reported no whitespace errors and staged changes were committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a3b635888327994bdbf3c9b3166c)