### PR TITLE
Simplify factory core loop to three deterministic phases

### DIFF
--- a/Assets/Scripts/Simulation/Core/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/Simulation/Core/FactoryCoreLoopSystem.cs
@@ -6,15 +6,13 @@ namespace FactoryMustScale.Simulation.Core
     /// Authoritative factory tick step order.
     ///
     /// This enum is intentionally explicit because we want one canonical sequence
-    /// shared by tests, debugging tools, and future domain systems (item/energy/logic/combat).
+    /// shared by tests, debugging tools, and future domain systems.
     /// </summary>
     public enum FactoryTickStep : byte
     {
-        IngestEvents = 0,
-        ApplyEvents = 1,
-        PrepareSimulation = 2,
-        RunSimulation = 3,
-        ExtractOutputs = 4,
+        InputAndEventHandling = 0,
+        CellProcessUpdate = 1,
+        PublishEventsForNextTick = 2,
     }
 
     /// <summary>
@@ -33,11 +31,9 @@ namespace FactoryMustScale.Simulation.Core
         public bool Running;
 
         // Deterministic phase counters for debugging/tests.
-        public int IngestEventsCount;
-        public int ApplyEventsCount;
-        public int PrepareSimulationCount;
-        public int RunSimulationCount;
-        public int ExtractOutputsCount;
+        public int InputAndEventHandlingCount;
+        public int CellProcessUpdateCount;
+        public int PublishEventsForNextTickCount;
 
         // Optional preallocated trace buffer.
         public int[] PhaseTraceBuffer;
@@ -61,16 +57,10 @@ namespace FactoryMustScale.Simulation.Core
     /// <summary>
     /// Core factory loop skeleton with explicit phase ordering.
     ///
-    /// Current scope:
-    /// - Establishes and documents the final high-level tick cycle.
-    /// - Does not implement domain simulation logic yet.
-    ///
     /// Phase contract (per tick):
-    /// 1) IngestEvents: pull high-rate input/combat events into the factory tick boundary.
-    /// 2) ApplyEvents: apply structural commands (build/remove/rotate/reconfigure).
-    /// 3) PrepareSimulation: resolve derived data snapshots for the tick.
-    /// 4) RunSimulation: execute deterministic domain simulation updates.
-    /// 5) ExtractOutputs: publish results/events/debug output after state update.
+    /// 1) InputAndEventHandling: read player/system input and consume incoming tick events.
+    /// 2) CellProcessUpdate: execute deterministic per-cell processing for this tick.
+    /// 3) PublishEventsForNextTick: emit cell process results as events consumed next tick.
     ///
     /// This ordering matches the simulation rules document and should remain stable.
     /// </summary>
@@ -83,11 +73,9 @@ namespace FactoryMustScale.Simulation.Core
                 return;
             }
 
-            IngestEvents(ref state, tickIndex);
-            ApplyEvents(ref state, tickIndex);
-            PrepareSimulation(ref state, tickIndex);
-            RunSimulation(ref state, tickIndex);
-            ExtractOutputs(ref state, tickIndex);
+            InputAndEventHandling(ref state, tickIndex);
+            CellProcessUpdate(ref state, tickIndex);
+            PublishEventsForNextTick(ref state, tickIndex);
 
             state.FactoryTicksExecuted++;
             if (state.FactoryTicksExecuted >= state.MaxFactoryTicks)
@@ -96,35 +84,23 @@ namespace FactoryMustScale.Simulation.Core
             }
         }
 
-        private static void IngestEvents(ref FactoryCoreLoopState state, int tickIndex)
+        private static void InputAndEventHandling(ref FactoryCoreLoopState state, int tickIndex)
         {
-            state.IngestEventsCount++;
-            AppendTrace(ref state, FactoryTickStep.IngestEvents, tickIndex);
+            state.InputAndEventHandlingCount++;
+            AppendTrace(ref state, FactoryTickStep.InputAndEventHandling, tickIndex);
         }
 
-        private static void ApplyEvents(ref FactoryCoreLoopState state, int tickIndex)
+        private static void CellProcessUpdate(ref FactoryCoreLoopState state, int tickIndex)
         {
-            state.ApplyEventsCount++;
-            AppendTrace(ref state, FactoryTickStep.ApplyEvents, tickIndex);
-        }
-
-        private static void PrepareSimulation(ref FactoryCoreLoopState state, int tickIndex)
-        {
-            state.PrepareSimulationCount++;
-            AppendTrace(ref state, FactoryTickStep.PrepareSimulation, tickIndex);
-        }
-
-        private static void RunSimulation(ref FactoryCoreLoopState state, int tickIndex)
-        {
-            state.RunSimulationCount++;
+            state.CellProcessUpdateCount++;
             ItemTransportPhaseSystem.Run(ref state);
-            AppendTrace(ref state, FactoryTickStep.RunSimulation, tickIndex);
+            AppendTrace(ref state, FactoryTickStep.CellProcessUpdate, tickIndex);
         }
 
-        private static void ExtractOutputs(ref FactoryCoreLoopState state, int tickIndex)
+        private static void PublishEventsForNextTick(ref FactoryCoreLoopState state, int tickIndex)
         {
-            state.ExtractOutputsCount++;
-            AppendTrace(ref state, FactoryTickStep.ExtractOutputs, tickIndex);
+            state.PublishEventsForNextTickCount++;
+            AppendTrace(ref state, FactoryTickStep.PublishEventsForNextTick, tickIndex);
         }
 
         private static void AppendTrace(ref FactoryCoreLoopState state, FactoryTickStep step, int tickIndex)

--- a/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
@@ -25,12 +25,10 @@ namespace FactoryMustScale.Tests.EditMode.Core
             harness.Tick(1);
 
             Assert.That(harness.State.FactoryTicksExecuted, Is.EqualTo(1));
-            Assert.That(harness.State.PhaseTraceCount, Is.EqualTo(5));
-            Assert.That(harness.State.PhaseTraceBuffer[0], Is.EqualTo((0 * 10) + (int)FactoryTickStep.IngestEvents));
-            Assert.That(harness.State.PhaseTraceBuffer[1], Is.EqualTo((0 * 10) + (int)FactoryTickStep.ApplyEvents));
-            Assert.That(harness.State.PhaseTraceBuffer[2], Is.EqualTo((0 * 10) + (int)FactoryTickStep.PrepareSimulation));
-            Assert.That(harness.State.PhaseTraceBuffer[3], Is.EqualTo((0 * 10) + (int)FactoryTickStep.RunSimulation));
-            Assert.That(harness.State.PhaseTraceBuffer[4], Is.EqualTo((0 * 10) + (int)FactoryTickStep.ExtractOutputs));
+            Assert.That(harness.State.PhaseTraceCount, Is.EqualTo(3));
+            Assert.That(harness.State.PhaseTraceBuffer[0], Is.EqualTo((0 * 10) + (int)FactoryTickStep.InputAndEventHandling));
+            Assert.That(harness.State.PhaseTraceBuffer[1], Is.EqualTo((0 * 10) + (int)FactoryTickStep.CellProcessUpdate));
+            Assert.That(harness.State.PhaseTraceBuffer[2], Is.EqualTo((0 * 10) + (int)FactoryTickStep.PublishEventsForNextTick));
         }
 
         [Test]
@@ -55,12 +53,10 @@ namespace FactoryMustScale.Tests.EditMode.Core
 
             Assert.That(harness.State.FactoryTicksExecuted, Is.EqualTo(maxTicks));
             Assert.That(harness.State.Running, Is.False);
-            Assert.That(harness.State.IngestEventsCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.ApplyEventsCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.PrepareSimulationCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.RunSimulationCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.ExtractOutputsCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.PhaseTraceCount, Is.EqualTo(maxTicks * 5));
+            Assert.That(harness.State.InputAndEventHandlingCount, Is.EqualTo(maxTicks));
+            Assert.That(harness.State.CellProcessUpdateCount, Is.EqualTo(maxTicks));
+            Assert.That(harness.State.PublishEventsForNextTickCount, Is.EqualTo(maxTicks));
+            Assert.That(harness.State.PhaseTraceCount, Is.EqualTo(maxTicks * 3));
         }
     }
 }


### PR DESCRIPTION
### Motivation

- Simplify and clarify the factory core tick pipeline to the requested three-step model: input/event handling, per-cell processing, and publishing cell results as events for the next tick while preserving determinism and testability.
- Provide a canonical, testable phase contract so domain systems can be routed through a stable skeleton without changing ordering semantics.

### Description

- Replaced the 5-step `FactoryTickStep` enum with three explicit steps: `InputAndEventHandling`, `CellProcessUpdate`, and `PublishEventsForNextTick`.
- Replaced per-phase counters in `FactoryCoreLoopState` to match the new three-phase model (`InputAndEventHandlingCount`, `CellProcessUpdateCount`, `PublishEventsForNextTickCount`).
- Updated `FactoryCoreLoopSystem.Tick` to invoke `InputAndEventHandling`, `CellProcessUpdate`, and `PublishEventsForNextTick` in that order, preserved deterministic trace capture via `AppendTrace`, and preserved `ItemTransportPhaseSystem.Run` inside the `CellProcessUpdate` phase.
- Updated EditMode test `Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs` to assert the new 3-step trace ordering, per-phase counters, and `PhaseTraceCount == maxTicks * 3` expectations.
- Known limitations: the loop remains a skeleton (no concrete event buffer payloads yet) and domain-level event channels are not yet implemented; next logical steps are to add preallocated event buffers and wire phases to produce/consume them and to add tests verifying cross-tick event carry-over.

### Testing

- Updated `Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs` to reflect the new phase ordering and counters; these tests are EditMode unit tests intended to be run in the Unity Test Runner.
- Ran repository static checks and pattern searches (`git diff --check`, `rg`) to ensure references to the old phase names were updated and no diff-check issues were introduced, and those checks passed.
- No runtime test failures observed from the static checks; run the Unity EditMode test suite to validate changes under the Unity test runner (recommended step before merging).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993e094ed00832796887453ca977f50)