### PR TITLE
Unify lifecycle and transport into a single deterministic row-major scan

### DIFF
--- a/Assets/Scripts/Simulation/Core/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/Simulation/Core/FactoryCoreLoopSystem.cs
@@ -55,6 +55,9 @@ namespace FactoryMustScale.Simulation.Core
 
         // Item transport process state and scratch buffers (reused, no hot-path allocations).
         public int ItemTransportProgressThreshold;
+        public SimEventBuffer SimEvents;
+        public int SimEventCapacity;
+        public int[] StorageItemCountByCell;
         public int[] ItemPayloadByCell;
         public int[] ItemTransportProgressByCell;
         public int[] ItemIntentTargetBySource;
@@ -112,6 +115,10 @@ namespace FactoryMustScale.Simulation.Core
 
         private static void InputAndEventHandling(ref FactoryCoreLoopState state, int tickIndex)
         {
+            int simEventCapacity = state.SimEventCapacity > 0 ? state.SimEventCapacity : 128;
+            state.SimEvents.EnsureCapacity(simEventCapacity);
+            state.SimEvents.BeginTick();
+            state.SimEvents.PromoteQueuedEvents();
             ItemTransportPhaseSystem.IngestEvents(ref state);
             state.InputAndEventHandlingCount++;
             AppendTrace(ref state, FactoryTickStep.EventCommit, tickIndex);

--- a/Assets/Scripts/Simulation/Item/FactoryItemLifecycleSystem.cs
+++ b/Assets/Scripts/Simulation/Item/FactoryItemLifecycleSystem.cs
@@ -1,0 +1,69 @@
+namespace FactoryMustScale.Simulation.Item
+{
+    using FactoryMustScale.Simulation.Core;
+
+    public static class FactoryItemLifecycleSystem
+    {
+        private const int DefaultGeneratedItemType = 1;
+
+        public static void Run(ref FactoryCoreLoopState state, int tickIndex)
+        {
+            if (state.FactoryLayer == null)
+            {
+                return;
+            }
+
+            int payloadChannel = state.FactoryPayloadItemChannelIndex >= 0 ? state.FactoryPayloadItemChannelIndex : 0;
+            int width = state.FactoryLayer.Width;
+            int height = state.FactoryLayer.Height;
+            int cellCount = width * height;
+
+            if (state.StorageItemCountByCell == null || state.StorageItemCountByCell.Length != cellCount)
+            {
+                state.StorageItemCountByCell = new int[cellCount];
+            }
+
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = state.FactoryLayer.MinX + localX;
+                    int cellIndex = rowStart + localX;
+
+                    if (!state.FactoryLayer.TryGet(x, y, out GridCellData cell))
+                    {
+                        continue;
+                    }
+
+                    if (cell.StateId == (int)GridStateId.Miner)
+                    {
+                        if (state.FactoryLayer.TryGetPayload(x, y, payloadChannel, out int payload) && payload == 0)
+                        {
+                            SimMutations.TryGenerateItem(state.FactoryLayer, payloadChannel, cellIndex, tickIndex, DefaultGeneratedItemType, ref state.SimEvents);
+                        }
+
+                        continue;
+                    }
+
+                    if (cell.StateId == (int)GridStateId.CrafterCore)
+                    {
+                        if (state.FactoryLayer.TryGetPayload(x, y, payloadChannel, out int payload) && payload != 0)
+                        {
+                            SimMutations.TryMutateItem(state.FactoryLayer, payloadChannel, cellIndex, tickIndex, payload + 100, ref state.SimEvents);
+                        }
+
+                        continue;
+                    }
+
+                    if (cell.StateId == (int)GridStateId.Storage)
+                    {
+                        SimMutations.TryStoreItem(state.FactoryLayer, payloadChannel, cellIndex, cellIndex, tickIndex, state.StorageItemCountByCell, ref state.SimEvents);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/SimEvent.cs
+++ b/Assets/Scripts/Simulation/SimEvent.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace FactoryMustScale.Simulation
+{
+    public enum SimEventEndpointKind : byte
+    {
+        None = 0,
+        Cell = 1,
+        Storage = 2,
+        World = 3,
+    }
+
+    public struct SimEvent
+    {
+        public SimEventId Id;
+        public int Tick;
+        public int SourceIndex;
+        public int TargetIndex;
+        public SimEventEndpointKind SourceKind;
+        public SimEventEndpointKind TargetKind;
+        public int ItemType;
+        public int ItemCount;
+        public int ValueA;
+        public int ValueB;
+
+        public override string ToString()
+        {
+            return string.Format(
+                "Tick={0} Id={1} Src({2}:{3}) Dst({4}:{5}) Item={6}x{7} A={8} B={9}",
+                Tick,
+                Id,
+                SourceKind,
+                SourceIndex,
+                TargetKind,
+                TargetIndex,
+                ItemType,
+                ItemCount,
+                ValueA,
+                ValueB);
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/SimEventBuffer.cs
+++ b/Assets/Scripts/Simulation/SimEventBuffer.cs
@@ -1,0 +1,139 @@
+using System;
+using System.Text;
+
+namespace FactoryMustScale.Simulation
+{
+    public struct SimEventBuffer
+    {
+        private SimEvent[] _workingEvents;
+        private int _workingCount;
+        private SimEvent[] _nextEvents;
+        private int _nextCount;
+        private SimEvent[] _tickEvents;
+        private int _tickCount;
+        private SimEvent[] _history;
+        private int _historyCount;
+        private bool _overflowed;
+
+        public int WorkingCount => _workingCount;
+        public int TickCount => _tickCount;
+        public int HistoryCount => _historyCount;
+        public bool Overflowed => _overflowed;
+
+        public void EnsureCapacity(int capacity)
+        {
+            if (capacity <= 0)
+            {
+                capacity = 1;
+            }
+
+            EnsureArray(ref _workingEvents, capacity);
+            EnsureArray(ref _nextEvents, capacity);
+            EnsureArray(ref _tickEvents, capacity);
+            EnsureArray(ref _history, checked(capacity * 16));
+        }
+
+        public void BeginTick()
+        {
+            _tickCount = 0;
+            _overflowed = false;
+        }
+
+        public void PromoteQueuedEvents()
+        {
+            _workingCount = _nextCount;
+            for (int i = 0; i < _nextCount; i++)
+            {
+                _workingEvents[i] = _nextEvents[i];
+            }
+
+            _nextCount = 0;
+        }
+
+        public bool TryGetWorkingEvent(int index, out SimEvent simEvent)
+        {
+            if (index < 0 || index >= _workingCount)
+            {
+                simEvent = default;
+                return false;
+            }
+
+            simEvent = _workingEvents[index];
+            return true;
+        }
+
+        public bool QueueForNextTick(SimEvent simEvent)
+        {
+            if (!TryAppend(ref _nextEvents, ref _nextCount, simEvent))
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        public bool RecordApplied(SimEvent simEvent)
+        {
+            if (!TryAppend(ref _tickEvents, ref _tickCount, simEvent))
+            {
+                return false;
+            }
+
+            return TryAppend(ref _history, ref _historyCount, simEvent);
+        }
+
+        public bool TryGetHistoryEvent(int index, out SimEvent simEvent)
+        {
+            if (index < 0 || index >= _historyCount)
+            {
+                simEvent = default;
+                return false;
+            }
+
+            simEvent = _history[index];
+            return true;
+        }
+
+        public string DumpTickEvents()
+        {
+            if (_tickCount == 0)
+            {
+                return string.Empty;
+            }
+
+            StringBuilder builder = new StringBuilder();
+            for (int i = 0; i < _tickCount; i++)
+            {
+                if (i > 0)
+                {
+                    builder.Append('\n');
+                }
+
+                builder.Append(_tickEvents[i].ToString());
+            }
+
+            return builder.ToString();
+        }
+
+        private static void EnsureArray(ref SimEvent[] buffer, int capacity)
+        {
+            if (buffer == null || buffer.Length != capacity)
+            {
+                buffer = new SimEvent[capacity];
+            }
+        }
+
+        private bool TryAppend(ref SimEvent[] buffer, ref int count, SimEvent simEvent)
+        {
+            if (buffer == null || count >= buffer.Length)
+            {
+                _overflowed = true;
+                return false;
+            }
+
+            buffer[count] = simEvent;
+            count++;
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/Simulation/SimEventId.cs
+++ b/Assets/Scripts/Simulation/SimEventId.cs
@@ -1,0 +1,15 @@
+namespace FactoryMustScale.Simulation
+{
+    public enum SimEventId : byte
+    {
+        None = 0,
+        CellCreated = 1,
+        CellRemoved = 2,
+        CellRotated = 3,
+        ItemGenerated = 4,
+        ItemTransported = 5,
+        ItemMutated = 6,
+        ItemStored = 7,
+        ItemDeleted = 8,
+    }
+}

--- a/Assets/Scripts/Simulation/SimMutations.cs
+++ b/Assets/Scripts/Simulation/SimMutations.cs
@@ -1,0 +1,192 @@
+namespace FactoryMustScale.Simulation
+{
+    public static class SimMutations
+    {
+        public static bool TrySetCell(ref Layer layer, int x, int y, int stateId, int variantId, uint flags, int tickIndex, ref SimEventBuffer events)
+        {
+            if (layer == null || !layer.TryGet(x, y, out GridCellData before))
+            {
+                return false;
+            }
+
+            if (!layer.TrySetCellState(x, y, stateId, variantId, flags, tickIndex, out _))
+            {
+                return false;
+            }
+
+            int index = ((y - layer.MinY) * layer.Width) + (x - layer.MinX);
+            SimEventId eventId;
+            if (before.StateId == (int)GridStateId.Empty && stateId != (int)GridStateId.Empty)
+            {
+                eventId = SimEventId.CellCreated;
+            }
+            else if (before.StateId != (int)GridStateId.Empty && stateId == (int)GridStateId.Empty)
+            {
+                eventId = SimEventId.CellRemoved;
+            }
+            else
+            {
+                eventId = SimEventId.CellRotated;
+            }
+
+            events.RecordApplied(new SimEvent
+            {
+                Id = eventId,
+                Tick = tickIndex,
+                SourceKind = SimEventEndpointKind.Cell,
+                SourceIndex = index,
+                ValueA = stateId,
+                ValueB = variantId,
+            });
+
+            return true;
+        }
+
+        public static bool TryGenerateItem(Layer layer, int payloadChannel, int cellIndex, int tickIndex, int itemType, ref SimEventBuffer events)
+        {
+            if (!TrySetPayloadByIndex(layer, payloadChannel, cellIndex, itemType))
+            {
+                return false;
+            }
+
+            events.RecordApplied(new SimEvent
+            {
+                Id = SimEventId.ItemGenerated,
+                Tick = tickIndex,
+                SourceKind = SimEventEndpointKind.Cell,
+                SourceIndex = cellIndex,
+                ItemType = itemType,
+                ItemCount = 1,
+            });
+
+            return true;
+        }
+
+        public static bool QueueTransportForNextTick(int tickIndex, int sourceIndex, int targetIndex, SimEventEndpointKind sourceKind, SimEventEndpointKind targetKind, int itemType, ref SimEventBuffer events)
+        {
+            return events.QueueForNextTick(new SimEvent
+            {
+                Id = SimEventId.ItemTransported,
+                Tick = tickIndex,
+                SourceKind = sourceKind,
+                TargetKind = targetKind,
+                SourceIndex = sourceIndex,
+                TargetIndex = targetIndex,
+                ItemType = itemType,
+                ItemCount = 1,
+            });
+        }
+
+        public static bool TryApplyTransport(Layer layer, int payloadChannel, in SimEvent simEvent, int tickIndex, ref SimEventBuffer events)
+        {
+            if (simEvent.Id != SimEventId.ItemTransported)
+            {
+                return false;
+            }
+
+            if (simEvent.SourceKind != SimEventEndpointKind.Cell || simEvent.TargetKind != SimEventEndpointKind.Cell)
+            {
+                return false;
+            }
+
+            if (!TryGetPayloadByIndex(layer, payloadChannel, simEvent.SourceIndex, out int payload) || payload == 0)
+            {
+                return false;
+            }
+
+            if (!TryGetPayloadByIndex(layer, payloadChannel, simEvent.TargetIndex, out int targetPayload) || targetPayload != 0)
+            {
+                return false;
+            }
+
+            if (!TrySetPayloadByIndex(layer, payloadChannel, simEvent.TargetIndex, payload)
+                || !TrySetPayloadByIndex(layer, payloadChannel, simEvent.SourceIndex, 0))
+            {
+                return false;
+            }
+
+            SimEvent applied = simEvent;
+            applied.Tick = tickIndex;
+            applied.ItemType = payload;
+            events.RecordApplied(applied);
+            return true;
+        }
+
+        public static bool TryMutateItem(Layer layer, int payloadChannel, int cellIndex, int tickIndex, int newItemType, ref SimEventBuffer events)
+        {
+            if (!TrySetPayloadByIndex(layer, payloadChannel, cellIndex, newItemType))
+            {
+                return false;
+            }
+
+            events.RecordApplied(new SimEvent
+            {
+                Id = SimEventId.ItemMutated,
+                Tick = tickIndex,
+                SourceKind = SimEventEndpointKind.Cell,
+                SourceIndex = cellIndex,
+                ItemType = newItemType,
+                ItemCount = 1,
+            });
+
+            return true;
+        }
+
+        public static bool TryStoreItem(Layer layer, int payloadChannel, int cellIndex, int storageId, int tickIndex, int[] storageCounts, ref SimEventBuffer events)
+        {
+            if (!TryGetPayloadByIndex(layer, payloadChannel, cellIndex, out int payload) || payload == 0)
+            {
+                return false;
+            }
+
+            if (storageCounts != null && storageId >= 0 && storageId < storageCounts.Length)
+            {
+                storageCounts[storageId] += 1;
+            }
+
+            if (!TrySetPayloadByIndex(layer, payloadChannel, cellIndex, 0))
+            {
+                return false;
+            }
+
+            events.RecordApplied(new SimEvent
+            {
+                Id = SimEventId.ItemStored,
+                Tick = tickIndex,
+                SourceKind = SimEventEndpointKind.Cell,
+                TargetKind = SimEventEndpointKind.Storage,
+                SourceIndex = cellIndex,
+                TargetIndex = storageId,
+                ItemType = payload,
+                ItemCount = 1,
+            });
+
+            return true;
+        }
+
+        private static bool TryGetPayloadByIndex(Layer layer, int payloadChannel, int cellIndex, out int payload)
+        {
+            payload = 0;
+            if (layer == null)
+            {
+                return false;
+            }
+
+            int x = layer.MinX + (cellIndex % layer.Width);
+            int y = layer.MinY + (cellIndex / layer.Width);
+            return layer.TryGetPayload(x, y, payloadChannel, out payload);
+        }
+
+        private static bool TrySetPayloadByIndex(Layer layer, int payloadChannel, int cellIndex, int payload)
+        {
+            if (layer == null)
+            {
+                return false;
+            }
+
+            int x = layer.MinX + (cellIndex % layer.Width);
+            int y = layer.MinY + (cellIndex / layer.Width);
+            return layer.TrySetPayload(x, y, payloadChannel, payload);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Eliminate the separate lifecycle pass to ensure all per-cell decisions in a tick are made in a single deterministic row-major traversal so event ordering is stable and unambiguous. 
- Reduce duplicate grid scans and keep lifecycle mutations (generation, mutation, storage) visible to transport resolution in the same tick.

### Description
- Removed the separate lifecycle invocation from `FactoryCoreLoopSystem.CellProcessUpdate` and consolidated per-cell lifecycle logic into the transport phase implementation. 
- Refactored `ConveyorArbitratedPropagationSystem.ProcessCells` to perform one row-major scan and call `ApplyLifecycleByCell(...)` inline, then compute transport intents and arbitration deterministically. 
- Introduced a simple event model: added `SimEvent`, `SimEventId`, `SimEventBuffer`, and `SimMutations` to record, queue and apply simulation events such as `ItemGenerated`, `ItemMutated`, `ItemStored`, and `ItemTransported`. 
- Added `SimEvents` and `SimEventCapacity` to `FactoryCoreLoopState` and ensured storage counters (`StorageItemCountByCell`) and buffers are allocated by the unified system; kept deterministic winner selection (stable source-index precedence and merger round-robin). 
- Kept `FactoryItemLifecycleSystem.cs` in the tree as a standalone reference/alternative implementation, but removed its call from the core loop so the unified scan is authoritative (documented as an intentional choice in the PR). 

### Testing
- Updated EditMode tests in `Assets/Tests/EditMode/Core/FactoryCoreItemTransportTests.cs`, including a new `GeneratorToStorage_ProducesDeterministicUnifiedEventStream` that asserts deterministic event history and storage behavior. 
- Attempted to run automated tests in this environment with `dotnet test`, but the runtime is unavailable here so no tests were executed; local execution is required to validate the test suite. 
- Authors should run the EditMode tests locally (or in CI/Unity) to confirm all assertions pass and to verify deterministic ordering across runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993ff16ba7c8327837af47bc0f78922)