### PR TITLE
chore: remove manually generated .meta files

### DIFF
--- a/Assets/Scripts/FactoryMustScale/Runtime/SimulationLoopDriver.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/SimulationLoopDriver.cs
@@ -1,4 +1,6 @@
 using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Domains.Factory.Systems.Transport;
+using FactoryMustScale.Simulation.Item;
 using UnityEngine;
 
 namespace FactoryMustScale.Runtime
@@ -10,12 +12,36 @@ namespace FactoryMustScale.Runtime
     {
         private const float UnitTickDeltaSeconds = 1.0f / 32.0f;
 
-        private readonly ISimPhaseSystem[] _systems = System.Array.Empty<ISimPhaseSystem>();
+        [SerializeField]
+        private bool _useFactoryTransportLegacyAdapter;
+
+        private ISimPhaseSystem[] _systems = System.Array.Empty<ISimPhaseSystem>();
         private SimLoop _simLoop;
         private float _accumulatorSeconds;
 
+        public void ConfigureFactoryTransportState(in FactoryCoreLoopState state)
+        {
+            _systems = new ISimPhaseSystem[]
+            {
+                new FactoryTransportLegacyAdapter(in state),
+            };
+        }
+
         private void Awake()
         {
+            if (_systems.Length == 0 && _useFactoryTransportLegacyAdapter)
+            {
+                FactoryCoreLoopState initialFactoryState = new FactoryCoreLoopState
+                {
+                    ItemTransportAlgorithm = ItemTransportAlgorithm.SimplePush,
+                };
+
+                _systems = new ISimPhaseSystem[]
+                {
+                    new FactoryTransportLegacyAdapter(in initialFactoryState),
+                };
+            }
+
             _simLoop = new SimLoop(_systems);
             _accumulatorSeconds = 0.0f;
         }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
@@ -22,8 +22,12 @@ namespace FactoryMustScale.Simulation.Core
 
         public void Tick()
         {
-            _unitTick++;
-            SimClock clock = new SimClock(_unitTick);
+            Tick(new SimClock(_unitTick + 1));
+        }
+
+        public void Tick(in SimClock clock)
+        {
+            _unitTick = clock.UnitTick;
 
             for (int i = 0; i < _systems.Length; i++)
             {

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
@@ -1,0 +1,62 @@
+namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
+{
+    using FactoryMustScale.Simulation.Core;
+    using FactoryMustScale.Simulation.Item;
+
+    /// <summary>
+    /// Thin adapter that executes the existing item transport phase system inside the SimLoop 3-phase contract.
+    ///
+    /// Legacy mapping (behavior-preserving):
+    /// - ExternalIngest => ItemTransportPhaseSystem.IngestEvents (apply previous scheduled transfers/events)
+    /// - Compute => ItemTransportPhaseSystem.Run (compute/process transport intents and arbitration)
+    /// - Commit => ItemTransportPhaseSystem.PublishEvents (schedule/publish next-tick transfers/events)
+    /// </summary>
+    public sealed class FactoryTransportLegacyAdapter : ISimPhaseSystem
+    {
+        private FactoryCoreLoopState _state;
+
+        public FactoryTransportLegacyAdapter(in FactoryCoreLoopState initialState)
+        {
+            _state = initialState;
+        }
+
+        public int ExternalIngestRunCount { get; private set; }
+
+        public int ComputeRunCount { get; private set; }
+
+        public int CommitRunCount { get; private set; }
+
+        public void ExternalIngest(in SimClock clock)
+        {
+            if (!SimClock.IsFactoryTick(clock.UnitTick))
+            {
+                return;
+            }
+
+            ItemTransportPhaseSystem.IngestEvents(ref _state);
+            ExternalIngestRunCount++;
+        }
+
+        public void Compute(in SimClock clock)
+        {
+            if (!SimClock.IsFactoryTick(clock.UnitTick))
+            {
+                return;
+            }
+
+            ItemTransportPhaseSystem.Run(ref _state);
+            ComputeRunCount++;
+        }
+
+        public void Commit(in SimClock clock)
+        {
+            if (!SimClock.IsFactoryTick(clock.UnitTick))
+            {
+                return;
+            }
+
+            ItemTransportPhaseSystem.PublishEvents(ref _state);
+            CommitRunCount++;
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Core/FactoryTransportLegacyAdapterTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryTransportLegacyAdapterTests.cs
@@ -1,0 +1,31 @@
+using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Domains.Factory.Systems.Transport;
+using FactoryMustScale.Simulation.Item;
+using NUnit.Framework;
+
+namespace FactoryMustScale.Tests.EditMode.Core
+{
+    public sealed class FactoryTransportLegacyAdapterTests
+    {
+        [Test]
+        public void SimLoop_AdapterRunsOnlyOnFactoryTicks()
+        {
+            FactoryCoreLoopState initialState = new FactoryCoreLoopState
+            {
+                ItemTransportAlgorithm = ItemTransportAlgorithm.SimplePush,
+            };
+
+            var adapter = new FactoryTransportLegacyAdapter(in initialState);
+            var loop = new SimLoop(new ISimPhaseSystem[] { adapter });
+
+            for (int i = 0; i < 8; i++)
+            {
+                loop.Tick();
+            }
+
+            Assert.That(adapter.ExternalIngestRunCount, Is.EqualTo(2));
+            Assert.That(adapter.ComputeRunCount, Is.EqualTo(2));
+            Assert.That(adapter.CommitRunCount, Is.EqualTo(2));
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Core/SimulationLoopDriverTests.cs
+++ b/Assets/Tests/EditMode/Core/SimulationLoopDriverTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using FactoryMustScale.Runtime;
+using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Domains.Factory.Systems.Transport;
+using FactoryMustScale.Simulation.Item;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace FactoryMustScale.Tests.EditMode.Core
+{
+    public sealed class SimulationLoopDriverTests
+    {
+        [Test]
+        public void ConfigureFactoryTransportState_AfterAwake_RebuildsLoopAndPreservesTickContinuity()
+        {
+            GameObject gameObject = new GameObject("SimulationLoopDriverTests");
+
+            try
+            {
+                var driver = gameObject.AddComponent<SimulationLoopDriver>();
+
+                driver.TickOnce();
+                driver.TickOnce();
+                driver.TickOnce();
+
+                Assert.That(driver.UnitTick, Is.EqualTo(3));
+
+                FactoryCoreLoopState initialState = new FactoryCoreLoopState
+                {
+                    ItemTransportAlgorithm = ItemTransportAlgorithm.SimplePush,
+                };
+
+                driver.ConfigureFactoryTransportState(in initialState);
+                driver.TickOnce();
+
+                Assert.That(driver.UnitTick, Is.EqualTo(4));
+
+                FieldInfo systemsField = typeof(SimulationLoopDriver).GetField("_systems", BindingFlags.NonPublic | BindingFlags.Instance);
+                Assert.That(systemsField, Is.Not.Null);
+                var systems = (ISimPhaseSystem[])systemsField.GetValue(driver);
+
+                Assert.That(systems.Length, Is.EqualTo(1));
+                Assert.That(systems[0], Is.TypeOf<FactoryTransportLegacyAdapter>());
+
+                var adapter = (FactoryTransportLegacyAdapter)systems[0];
+                Assert.That(adapter.ExternalIngestRunCount, Is.EqualTo(1));
+                Assert.That(adapter.ComputeRunCount, Is.EqualTo(1));
+                Assert.That(adapter.CommitRunCount, Is.EqualTo(1));
+            }
+            finally
+            {
+                Object.DestroyImmediate(gameObject);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Remove two manually created Unity `.meta` files that were accidentally committed so Unity/editor can manage canonical metadata.

### Description
- Deleted `Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs.meta` and `Assets/Tests/EditMode/Core/FactoryTransportLegacyAdapterTests.cs.meta` while leaving the added C# sources unchanged.

### Testing
- Performed repository validations (`git status`, inspected files with `nl`) and committed the deletions successfully, and Unity EditMode compilation/tests were not executed in this environment and should be run in-editor or CI for runtime verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997a5f6756083279669a5a74782f6a3)