### PR TITLE
Refactor simulation core loop to canonical 3-phase contract

### DIFF
--- a/Assets/Scripts/FactoryMustScale/Runtime/SimulationLoopDriver.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/SimulationLoopDriver.cs
@@ -1,4 +1,5 @@
 using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Legacy;
 using FactoryMustScale.Simulation.Domains.Factory.Systems.Transport;
 using FactoryMustScale.Simulation.Item;
 using UnityEngine;

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/ISimSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/ISimSystem.cs
@@ -1,20 +1,19 @@
 namespace FactoryMustScale.Simulation.Core
 {
     /// <summary>
-    /// Defines the contract for a simulation system that participates in a time-stepped simulation. Provides methods
-    /// for the 3 phases: 1) ingesting external inputs, 2) performing computation, and 3) committing state changes at a given simulation clock
-    /// step (tick).
+    /// Canonical deterministic simulation system contract.
+    ///
+    /// Phase contract:
+    /// 1) ExternalIngest: read external commands/intents into transient buffers.
+    /// 2) Compute: read-only computation that emits intents/deltas/events.
+    /// 3) Commit: the only phase allowed to mutate authoritative state.
     /// </summary>
-    /// <remarks>Implementations of this interface are expected to process simulation logic in discrete
-    /// phases, coordinated by the provided simulation clock. Each method should be called in sequence within a
-    /// simulation step: first ExternalIngest, then Compute, and finally Commit. This interface is intended for use in
-    /// simulation frameworks where multiple systems advance together in lockstep.</remarks>
     public interface ISimSystem
     {
-        void ExternalIngest(in SimClock clock);
+        void ExternalIngest(ref SimContext ctx);
 
-        void Compute(in SimClock clock);
+        void Compute(ref SimContext ctx);
 
-        void Commit(in SimClock clock);
+        void Commit(ref SimContext ctx);
     }
 }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimClock.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimClock.cs
@@ -2,10 +2,15 @@ namespace FactoryMustScale.Simulation.Core
 {
     /// <summary>
     /// Authoritative simulation clock based on unit ticks.
-    /// Unit tick base rate is 32 Hz.
+    /// UnitTick advances at 32 Hz.
+    /// FactoryTick occurs every 4 UnitTicks.
+    /// EnvTick occurs every 32 UnitTicks.
     /// </summary>
     public readonly struct SimClock
     {
+        public const int UnitTicksPerFactoryTick = 4;
+        public const int UnitTicksPerEnvTick = 32;
+
         public SimClock(int unitTick)
         {
             UnitTick = unitTick;
@@ -13,14 +18,22 @@ namespace FactoryMustScale.Simulation.Core
 
         public int UnitTick { get; }
 
+        public int FactoryTick => UnitTick / UnitTicksPerFactoryTick;
+
+        public int EnvTick => UnitTick / UnitTicksPerEnvTick;
+
+        public bool IsFactoryTick => IsFactoryTick(UnitTick);
+
+        public bool IsEnvTick => IsEnvTick(UnitTick);
+
         public static bool IsFactoryTick(int unitTick)
         {
-            return (unitTick % 4) == 0;
+            return (unitTick % UnitTicksPerFactoryTick) == 0;
         }
 
         public static bool IsEnvTick(int unitTick)
         {
-            return (unitTick % 32) == 0;
+            return (unitTick % UnitTicksPerEnvTick) == 0;
         }
     }
 }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimContext.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimContext.cs
@@ -1,0 +1,55 @@
+namespace FactoryMustScale.Simulation.Core
+{
+    /// <summary>
+    /// Shared per-tick simulation context.
+    ///
+    /// Contract:
+    /// - ExternalIngest and Compute can read authoritative state and write transient buffers only.
+    /// - Commit is the only phase that may apply authoritative state mutations.
+    /// </summary>
+    public struct SimContext
+    {
+        private readonly int[] _phaseTraceBuffer;
+
+        public SimContext(in SimClock clock, int[] phaseTraceBuffer)
+        {
+            Clock = clock;
+            _phaseTraceBuffer = phaseTraceBuffer;
+            PhaseTraceCount = 0;
+        }
+
+        public SimClock Clock { get; }
+
+        public int PhaseTraceCount { get; private set; }
+
+        public void AppendPhaseTrace(SimPhase phase)
+        {
+            if (_phaseTraceBuffer == null || PhaseTraceCount >= _phaseTraceBuffer.Length)
+            {
+                return;
+            }
+
+            _phaseTraceBuffer[PhaseTraceCount] = (Clock.UnitTick * 10) + (int)phase;
+            PhaseTraceCount++;
+        }
+
+        public bool TryGetPhaseTraceAt(int index, out int traceValue)
+        {
+            if (_phaseTraceBuffer == null || index < 0 || index >= PhaseTraceCount)
+            {
+                traceValue = 0;
+                return false;
+            }
+
+            traceValue = _phaseTraceBuffer[index];
+            return true;
+        }
+    }
+
+    public enum SimPhase : byte
+    {
+        ExternalIngest = 0,
+        Compute = 1,
+        Commit = 2,
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimHash.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimHash.cs
@@ -1,0 +1,16 @@
+namespace FactoryMustScale.Simulation.Core
+{
+    /// <summary>
+    /// Deterministic state hash helper (stub).
+    /// </summary>
+    public static class SimHash
+    {
+        public static int Fold(int seed, int value)
+        {
+            unchecked
+            {
+                return (seed * 397) ^ value;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
@@ -2,23 +2,49 @@ using System;
 
 namespace FactoryMustScale.Simulation.Core
 {
+    /// <summary>
+    /// Runs the canonical 3-phase simulation loop in deterministic system index order.
+    /// </summary>
     public sealed class SimLoop
     {
         private readonly ISimSystem[] _systems;
+        private readonly int[] _phaseTraceBuffer;
         private int _unitTick;
+        private int _phaseTraceCount;
 
-        public SimLoop(ISimSystem[] systems)
+        public SimLoop(ISimSystem[] systems, int traceCapacity = 1024)
         {
             if (systems == null)
             {
                 throw new ArgumentNullException(nameof(systems));
             }
 
+            if (traceCapacity < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(traceCapacity));
+            }
+
             _systems = systems;
+            _phaseTraceBuffer = traceCapacity == 0 ? Array.Empty<int>() : new int[traceCapacity];
             _unitTick = 0;
+            _phaseTraceCount = 0;
         }
 
         public int UnitTick => _unitTick;
+
+        public int PhaseTraceCount => _phaseTraceCount;
+
+        public bool TryGetPhaseTraceAt(int index, out int traceValue)
+        {
+            if (index < 0 || index >= _phaseTraceCount)
+            {
+                traceValue = 0;
+                return false;
+            }
+
+            traceValue = _phaseTraceBuffer[index];
+            return true;
+        }
 
         public void Tick()
         {
@@ -29,19 +55,33 @@ namespace FactoryMustScale.Simulation.Core
         {
             _unitTick = clock.UnitTick;
 
-            for (int i = 0; i < _systems.Length; i++)
-            {
-                _systems[i].ExternalIngest(in clock);
-            }
+            SimContext ctx = new SimContext(in clock, _phaseTraceBuffer);
 
-            for (int i = 0; i < _systems.Length; i++)
-            {
-                _systems[i].Compute(in clock);
-            }
+            ExecutePhase(ref ctx, SimPhase.ExternalIngest);
+            ExecutePhase(ref ctx, SimPhase.Compute);
+            ExecutePhase(ref ctx, SimPhase.Commit);
 
+            _phaseTraceCount = ctx.PhaseTraceCount;
+        }
+
+        private void ExecutePhase(ref SimContext ctx, SimPhase phase)
+        {
             for (int i = 0; i < _systems.Length; i++)
             {
-                _systems[i].Commit(in clock);
+                switch (phase)
+                {
+                    case SimPhase.ExternalIngest:
+                        _systems[i].ExternalIngest(ref ctx);
+                        break;
+                    case SimPhase.Compute:
+                        _systems[i].Compute(ref ctx);
+                        break;
+                    default:
+                        _systems[i].Commit(ref ctx);
+                        break;
+                }
+
+                ctx.AppendPhaseTrace(phase);
             }
         }
     }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoopSmokeTestSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoopSmokeTestSystem.cs
@@ -8,13 +8,13 @@ namespace FactoryMustScale.Simulation.Core
         public int LastPhaseMarker { get; private set; }
         public int LastObservedTick { get; private set; }
 
-        public void ExternalIngest(in SimClock clock)
+        public void ExternalIngest(ref SimContext ctx)
         {
-            LastObservedTick = clock.UnitTick;
+            LastObservedTick = ctx.Clock.UnitTick;
             LastPhaseMarker = 1;
         }
 
-        public void Compute(in SimClock clock)
+        public void Compute(ref SimContext ctx)
         {
             if (LastPhaseMarker == 1)
             {
@@ -22,7 +22,7 @@ namespace FactoryMustScale.Simulation.Core
             }
         }
 
-        public void Commit(in SimClock clock)
+        public void Commit(ref SimContext ctx)
         {
             if (LastPhaseMarker == 2)
             {

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/ConveyorArbitratedPropagationSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/ConveyorArbitratedPropagationSystem.cs
@@ -1,6 +1,6 @@
 namespace FactoryMustScale.Simulation.Item
 {
-    using FactoryMustScale.Simulation.Core;
+    using FactoryMustScale.Simulation.Legacy;
 
     public static class ConveyorArbitratedPropagationSystem
     {

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryItemLifecycleSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryItemLifecycleSystem.cs
@@ -1,6 +1,6 @@
 namespace FactoryMustScale.Simulation.Item
 {
-    using FactoryMustScale.Simulation.Core;
+    using FactoryMustScale.Simulation.Legacy;
 
     public static class FactoryItemLifecycleSystem
     {

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
@@ -2,14 +2,15 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
 {
     using FactoryMustScale.Simulation.Core;
     using FactoryMustScale.Simulation.Item;
+    using FactoryMustScale.Simulation.Legacy;
 
     /// <summary>
     /// Thin adapter that executes the existing item transport phase system inside the SimLoop 3-phase contract.
     ///
-    /// Legacy mapping (behavior-preserving):
-    /// - ExternalIngest => ItemTransportPhaseSystem.IngestEvents (apply previous scheduled transfers/events)
-    /// - Compute => ItemTransportPhaseSystem.Run (compute/process transport intents and arbitration)
-    /// - Commit => ItemTransportPhaseSystem.PublishEvents (schedule/publish next-tick transfers/events)
+    /// Legacy mapping under canonical 3-phase loop:
+    /// - ExternalIngest => SimEvent buffer ingest (BeginTick + PromoteQueuedEvents), no authoritative writes.
+    /// - Compute => ItemTransportPhaseSystem.Run + PublishEvents to produce deterministic intents/queued events.
+    /// - Commit => ItemTransportPhaseSystem.IngestEvents applies queued transport events to authoritative state.
     /// </summary>
     public sealed class FactoryTransportLegacyAdapter : ISimSystem
     {
@@ -26,36 +27,39 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
 
         public int CommitRunCount { get; private set; }
 
-        public void ExternalIngest(in SimClock clock)
+        public void ExternalIngest(ref SimContext ctx)
         {
-            if (!SimClock.IsFactoryTick(clock.UnitTick))
+            if (!ctx.Clock.IsFactoryTick)
             {
                 return;
             }
 
-            ItemTransportPhaseSystem.IngestEvents(ref _state);
+            _state.SimEvents.EnsureCapacity(_state.SimEventCapacity > 0 ? _state.SimEventCapacity : 128);
+            _state.SimEvents.BeginTick();
+            _state.SimEvents.PromoteQueuedEvents();
             ExternalIngestRunCount++;
         }
 
-        public void Compute(in SimClock clock)
+        public void Compute(ref SimContext ctx)
         {
-            if (!SimClock.IsFactoryTick(clock.UnitTick))
+            if (!ctx.Clock.IsFactoryTick)
             {
                 return;
             }
 
             ItemTransportPhaseSystem.Run(ref _state);
+            ItemTransportPhaseSystem.PublishEvents(ref _state);
             ComputeRunCount++;
         }
 
-        public void Commit(in SimClock clock)
+        public void Commit(ref SimContext ctx)
         {
-            if (!SimClock.IsFactoryTick(clock.UnitTick))
+            if (!ctx.Clock.IsFactoryTick)
             {
                 return;
             }
 
-            ItemTransportPhaseSystem.PublishEvents(ref _state);
+            ItemTransportPhaseSystem.IngestEvents(ref _state);
             CommitRunCount++;
         }
     }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/ItemTransportPhaseSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/ItemTransportPhaseSystem.cs
@@ -1,6 +1,6 @@
 namespace FactoryMustScale.Simulation.Item
 {
-    using FactoryMustScale.Simulation.Core;
+    using FactoryMustScale.Simulation.Legacy;
 
     /// <summary>
     /// Item-domain simulation entry points mapped to core loop phases.

--- a/Assets/Scripts/FactoryMustScale/Simulation/Legacy/Experiments/ConveyorGraphBasedExperimentalSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Legacy/Experiments/ConveyorGraphBasedExperimentalSystem.cs
@@ -1,6 +1,6 @@
 namespace FactoryMustScale.Simulation.Item
 {
-    using FactoryMustScale.Simulation.Core;
+    using FactoryMustScale.Simulation.Legacy;
 
     /// <summary>
     /// Placeholder for a future graph-based conveyor item simulation (graph-based).

--- a/Assets/Scripts/FactoryMustScale/Simulation/Legacy/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Legacy/FactoryCoreLoopSystem.cs
@@ -1,4 +1,4 @@
-namespace FactoryMustScale.Simulation.Core
+namespace FactoryMustScale.Simulation.Legacy
 {
     using FactoryMustScale.Simulation.Item;
 

--- a/Assets/Scripts/FactoryMustScale/Simulation/Legacy/FixedStepSimulationHarness.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Legacy/FixedStepSimulationHarness.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace FactoryMustScale.Simulation
+namespace FactoryMustScale.Simulation.Legacy
 {
     /// <summary>
     /// Executes a simulation system on a deterministic fixed tick sequence.

--- a/Assets/Scripts/FactoryMustScale/Simulation/Legacy/ISimulationSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Legacy/ISimulationSystem.cs
@@ -1,4 +1,4 @@
-namespace FactoryMustScale.Simulation
+namespace FactoryMustScale.Simulation.Legacy
 {
     /// <summary>
     /// Minimal simulation contract for fixed-step systems.

--- a/Assets/Tests/EditMode/ConveyorPayloadMovementTests.cs
+++ b/Assets/Tests/EditMode/ConveyorPayloadMovementTests.cs
@@ -1,4 +1,3 @@
-using FactoryMustScale.Simulation;
 using FactoryMustScale.Simulation.Legacy;
 using NUnit.Framework;
 

--- a/Assets/Tests/EditMode/Core/FactoryCoreItemTransportTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryCoreItemTransportTests.cs
@@ -1,5 +1,6 @@
-using FactoryMustScale.Simulation;
+using FactoryMustScale.Simulation.Legacy;
 using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Legacy;
 using FactoryMustScale.Simulation.Item;
 using NUnit.Framework;
 using System.Text;

--- a/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
@@ -1,5 +1,6 @@
-using FactoryMustScale.Simulation;
+using FactoryMustScale.Simulation.Legacy;
 using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Legacy;
 using NUnit.Framework;
 
 namespace FactoryMustScale.Tests.EditMode.Core

--- a/Assets/Tests/EditMode/Core/FactoryTransportLegacyAdapterTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryTransportLegacyAdapterTests.cs
@@ -1,4 +1,5 @@
 using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Legacy;
 using FactoryMustScale.Simulation.Domains.Factory.Systems.Transport;
 using FactoryMustScale.Simulation.Item;
 using NUnit.Framework;

--- a/Assets/Tests/EditMode/Core/SimLoopPhaseTraceTests.cs
+++ b/Assets/Tests/EditMode/Core/SimLoopPhaseTraceTests.cs
@@ -1,0 +1,51 @@
+using FactoryMustScale.Simulation.Core;
+using NUnit.Framework;
+
+namespace FactoryMustScale.Tests.EditMode.Core
+{
+    public sealed class SimLoopPhaseTraceTests
+    {
+        [Test]
+        public void Tick_RecordsCanonicalPhaseOrder()
+        {
+            var smoke = new SimLoopSmokeTestSystem();
+            var loop = new SimLoop(new ISimSystem[] { smoke }, traceCapacity: 8);
+
+            loop.Tick();
+
+            Assert.That(smoke.LastObservedTick, Is.EqualTo(1));
+            Assert.That(smoke.LastPhaseMarker, Is.EqualTo(3));
+            Assert.That(loop.PhaseTraceCount, Is.EqualTo(3));
+
+            Assert.That(loop.TryGetPhaseTraceAt(0, out int trace0), Is.True);
+            Assert.That(loop.TryGetPhaseTraceAt(1, out int trace1), Is.True);
+            Assert.That(loop.TryGetPhaseTraceAt(2, out int trace2), Is.True);
+
+            Assert.That(trace0, Is.EqualTo((1 * 10) + (int)SimPhase.ExternalIngest));
+            Assert.That(trace1, Is.EqualTo((1 * 10) + (int)SimPhase.Compute));
+            Assert.That(trace2, Is.EqualTo((1 * 10) + (int)SimPhase.Commit));
+        }
+
+        [Test]
+        public void Tick_MultipleTicksRemainDeterministic()
+        {
+            var loopA = new SimLoop(new ISimSystem[] { new SimLoopSmokeTestSystem() }, traceCapacity: 8);
+            var loopB = new SimLoop(new ISimSystem[] { new SimLoopSmokeTestSystem() }, traceCapacity: 8);
+
+            loopA.Tick();
+            loopA.Tick();
+            loopB.Tick();
+            loopB.Tick();
+
+            Assert.That(loopA.PhaseTraceCount, Is.EqualTo(3));
+            Assert.That(loopB.PhaseTraceCount, Is.EqualTo(3));
+
+            for (int i = 0; i < 3; i++)
+            {
+                Assert.That(loopA.TryGetPhaseTraceAt(i, out int a), Is.True);
+                Assert.That(loopB.TryGetPhaseTraceAt(i, out int b), Is.True);
+                Assert.That(a, Is.EqualTo(b));
+            }
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Core/SimulationLoopDriverTests.cs
+++ b/Assets/Tests/EditMode/Core/SimulationLoopDriverTests.cs
@@ -1,6 +1,7 @@
 using System.Reflection;
 using FactoryMustScale.Runtime;
 using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Legacy;
 using FactoryMustScale.Simulation.Domains.Factory.Systems.Transport;
 using FactoryMustScale.Simulation.Item;
 using NUnit.Framework;

--- a/Assets/Tests/EditMode/FactoryCommandApplicationTests.cs
+++ b/Assets/Tests/EditMode/FactoryCommandApplicationTests.cs
@@ -1,4 +1,3 @@
-using FactoryMustScale.Simulation;
 using FactoryMustScale.Simulation.Legacy;
 using NUnit.Framework;
 

--- a/Assets/Tests/EditMode/MinimalFactoryGameLoopTests.cs
+++ b/Assets/Tests/EditMode/MinimalFactoryGameLoopTests.cs
@@ -1,4 +1,3 @@
-using FactoryMustScale.Simulation;
 using FactoryMustScale.Simulation.Legacy;
 using NUnit.Framework;
 

--- a/Assets/Tests/EditMode/SimulationHarnessDeterminismTests.cs
+++ b/Assets/Tests/EditMode/SimulationHarnessDeterminismTests.cs
@@ -1,4 +1,3 @@
-using FactoryMustScale.Simulation;
 using FactoryMustScale.Simulation.Legacy;
 using NUnit.Framework;
 using System;

--- a/Assets/Tests/EditMode/TwoPhaseHarnessTests.cs
+++ b/Assets/Tests/EditMode/TwoPhaseHarnessTests.cs
@@ -1,4 +1,4 @@
-using FactoryMustScale.Simulation;
+using FactoryMustScale.Simulation.Legacy;
 using NUnit.Framework;
 using System;
 


### PR DESCRIPTION
### Motivation
- Enforce the canonical 3-phase deterministic simulation contract (ExternalIngest → Compute → Commit) from NamespaceStructure.md so only Commit mutates authoritative state.
- Provide a single deterministic SimLoop and SimClock cadence (UnitTick=32Hz, FactoryTick every 4 unit ticks, EnvTick every 32) usable by runtime drivers and tests.
- Isolate legacy two-phase harness/loop code to a `Legacy` namespace so the new core loop can be integrated incrementally without large rewrites of adapters.

### Description
- Added core API and types under `FactoryMustScale.Simulation.Core`: `ISimSystem` (3-phase methods), `SimContext` (per-tick shared context & tracing), `SimClock` (unit/factory/env helpers), `SimLoop` (runs ExternalIngest→Compute→Commit deterministically), and `SimHash` (compile-safe stub).
- Implemented deterministic phase tracing via a preallocated trace buffer owned by `SimLoop` and exposed through `SimContext` so tools/tests can assert phase ordering.
- Adapted existing item-transport adapter to the new contract (`FactoryTransportLegacyAdapter`): `ExternalIngest` now prepares `SimEvents` (`EnsureCapacity` + `BeginTick` + `PromoteQueuedEvents`) without applying authoritative mutations, `Compute` runs transport processing and publishes intents/events, and `Commit` applies queued transport events to authoritative state.
- Moved older two-phase harness and core loop types into `FactoryMustScale.Simulation.Legacy` (quarantine) and updated runtime wiring and tests to reference the `Legacy` namespace to avoid coupling new core code to legacy contracts.
- Added an EditMode smoke/determinism test `Assets/Tests/EditMode/Core/SimLoopPhaseTraceTests.cs` that asserts a single tick produces the phase trace ExternalIngest, Compute, Commit and that multiple runs remain deterministic.

### Testing
- Repository static checks: `git diff --check` completed with no issues.
- Added automated EditMode test `Assets/Tests/EditMode/Core/SimLoopPhaseTraceTests.cs` for canonical phase ordering, and updated existing EditMode tests to reference the quarantined `Legacy` namespace; these tests are intended to be run in Unity's EditMode test runner.
- Grep/search validations were performed to ensure core/legacy symbols and references were updated consistently (deterministic ordering and namespace changes confirmed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699ce73608688327a43f18fdfa8020ef)