### PR TITLE
Introduce `PreCompute` phase (replaces `ExternalIngest`), allow early structural edits, and tighten GridCellData process-profile handling

### DIFF
--- a/Assets/Scripts/FactoryMustScale/Simulation/Common/Grid/GridCellData.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Common/Grid/GridCellData.cs
@@ -173,6 +173,12 @@ namespace FactoryMustScale.Simulation
         /// </summary>
         public static int SetProcessProfileId(int variantId, byte processProfileId)
         {
+#if UNITY_EDITOR
+            if (processProfileId > Variant5Mask)
+            {
+                UnityEngine.Debug.LogError($"ProcessProfileId {processProfileId} exceeds 5-bit Variant/Profile range (0..{Variant5Mask}). Value will be clamped.");
+            }
+#endif
             return SetVariant5(variantId, processProfileId);
         }
 

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/ISimSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/ISimSystem.cs
@@ -4,13 +4,15 @@ namespace FactoryMustScale.Simulation.Core
     /// Canonical deterministic simulation system contract.
     ///
     /// Phase contract:
-    /// 1) ExternalIngest: read external commands/intents into transient buffers.
+    /// 1) PreCompute:
+    ///    A) ingest external commands/intents into transient buffers,
+    ///    B) apply structural cell edits early (build/remove/rotate) when required.
     /// 2) Compute: read-only computation that emits intents/deltas/events.
-    /// 3) Commit: the only phase allowed to mutate authoritative state.
+    /// 3) Commit: apply non-structural authoritative mutations only.
     /// </summary>
     public interface ISimSystem
     {
-        void ExternalIngest(ref SimContext ctx);
+        void PreCompute(ref SimContext ctx);
 
         void Compute(ref SimContext ctx);
 

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimContext.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimContext.cs
@@ -4,8 +4,9 @@ namespace FactoryMustScale.Simulation.Core
     /// Shared per-tick simulation context.
     ///
     /// Contract:
-    /// - ExternalIngest and Compute can read authoritative state and write transient buffers only.
-    /// - Commit is the only phase that may apply authoritative state mutations.
+    /// - PreCompute(A) and Compute can read authoritative state and write transient buffers only.
+    /// - PreCompute(B) may apply structural cell edits only (build/remove/rotate).
+    /// - Commit applies non-structural authoritative mutations.
     /// </summary>
     public struct SimContext
     {
@@ -48,7 +49,7 @@ namespace FactoryMustScale.Simulation.Core
 
     public enum SimPhase : byte
     {
-        ExternalIngest = 0,
+        PreCompute = 0,
         Compute = 1,
         Commit = 2,
     }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
@@ -57,7 +57,7 @@ namespace FactoryMustScale.Simulation.Core
 
             SimContext ctx = new SimContext(in clock, _phaseTraceBuffer);
 
-            ExecutePhase(ref ctx, SimPhase.ExternalIngest);
+            ExecutePhase(ref ctx, SimPhase.PreCompute);
             ExecutePhase(ref ctx, SimPhase.Compute);
             ExecutePhase(ref ctx, SimPhase.Commit);
 
@@ -70,8 +70,8 @@ namespace FactoryMustScale.Simulation.Core
             {
                 switch (phase)
                 {
-                    case SimPhase.ExternalIngest:
-                        _systems[i].ExternalIngest(ref ctx);
+                    case SimPhase.PreCompute:
+                        _systems[i].PreCompute(ref ctx);
                         break;
                     case SimPhase.Compute:
                         _systems[i].Compute(ref ctx);

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoopSmokeTestSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoopSmokeTestSystem.cs
@@ -8,7 +8,7 @@ namespace FactoryMustScale.Simulation.Core
         public int LastPhaseMarker { get; private set; }
         public int LastObservedTick { get; private set; }
 
-        public void ExternalIngest(ref SimContext ctx)
+        public void PreCompute(ref SimContext ctx)
         {
             LastObservedTick = ctx.Clock.UnitTick;
             LastPhaseMarker = 1;

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/State/FactoryBuildSystemState.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/State/FactoryBuildSystemState.cs
@@ -1,0 +1,31 @@
+namespace FactoryMustScale.Simulation
+{
+    /// <summary>
+    /// Deterministic runtime state for factory structural cell modifications.
+    /// </summary>
+    public struct FactoryBuildSystemState
+    {
+        public Layer TerrainLayer;
+        public Layer FactoryLayer;
+        public int TerrainResourceChannelIndex;
+
+        public BuildableRuleData[] BuildableRules;
+        public FactoryFootprintData[] Footprints;
+
+        // External command input and deterministic per-tick output buffers.
+        public FactoryCommandQueue CommandQueue;
+        public FactoryCommandQueue StructuralIntentBuffer;
+        public FactoryCommandResultBuffer CommandResults;
+        public bool StopProcessingOnFailure;
+
+        // Conflict-resolution scratch (reused).
+        public int[] StructuralIntentWinnerByCell;
+        public int[] StructuralIntentWriteStampByCell;
+
+        // Deterministic active sets refreshed after structural mutations.
+        public int[] ActiveBeltCellIndices;
+        public int ActiveBeltCellCount;
+        public int[] ActiveProcessCellIndices;
+        public int ActiveProcessCellCount;
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Build/FactoryBuildStructuralSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Build/FactoryBuildStructuralSystem.cs
@@ -3,18 +3,18 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Build
     using FactoryMustScale.Simulation.Core;
 
     /// <summary>
-    /// Factory structural loop system under the canonical PreCompute/Compute/Commit contract.
+    /// Factory structural edit system under the canonical PreCompute/Compute/Commit contract.
     ///
     /// - PreCompute(A): ingest build/remove/rotate commands into structural intent buffer.
     /// - PreCompute(B): resolve deterministic conflicts and apply structural edits early.
     /// - Compute: read-only for GridCellData.
     /// - Commit: reserved for non-structural deltas.
     /// </summary>
-    public sealed class FactoryCoreLoopSystem : ISimSystem
+    public sealed class FactoryBuildStructuralSystem : ISimSystem
     {
         private FactoryBuildSystemState _state;
 
-        public FactoryCoreLoopSystem(in FactoryBuildSystemState initialState)
+        public FactoryBuildStructuralSystem(in FactoryBuildSystemState initialState)
         {
             _state = initialState;
         }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Build/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Build/FactoryCoreLoopSystem.cs
@@ -1,0 +1,371 @@
+namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Build
+{
+    using FactoryMustScale.Simulation.Core;
+
+    /// <summary>
+    /// Factory structural loop system under the canonical PreCompute/Compute/Commit contract.
+    ///
+    /// - PreCompute(A): ingest build/remove/rotate commands into structural intent buffer.
+    /// - PreCompute(B): resolve deterministic conflicts and apply structural edits early.
+    /// - Compute: read-only for GridCellData.
+    /// - Commit: reserved for non-structural deltas.
+    /// </summary>
+    public sealed class FactoryCoreLoopSystem : ISimSystem
+    {
+        private FactoryBuildSystemState _state;
+
+        public FactoryCoreLoopSystem(in FactoryBuildSystemState initialState)
+        {
+            _state = initialState;
+        }
+
+        public FactoryBuildSystemState State => _state;
+
+        public void PreCompute(ref SimContext ctx)
+        {
+            if (!ctx.Clock.IsFactoryTick)
+            {
+                return;
+            }
+
+            _state.CommandResults.Clear();
+            IngestStructuralIntents();
+            ApplyStructuralIntents(ctx.Clock.UnitTick);
+            _state.CommandQueue.Clear();
+        }
+
+        public void Compute(ref SimContext ctx)
+        {
+        }
+
+        public void Commit(ref SimContext ctx)
+        {
+        }
+
+        private void IngestStructuralIntents()
+        {
+            _state.StructuralIntentBuffer.Clear();
+
+            int commandCount = _state.CommandQueue.Count;
+            for (int i = 0; i < commandCount; i++)
+            {
+                FactoryCommand command = _state.CommandQueue.GetAt(i);
+                if (command.Type == FactoryCommandType.PlaceBuilding
+                    || command.Type == FactoryCommandType.RemoveBuilding
+                    || command.Type == FactoryCommandType.RotateBuilding)
+                {
+                    _state.StructuralIntentBuffer.TryEnqueue(command);
+                }
+            }
+        }
+
+        private void ApplyStructuralIntents(int tickIndex)
+        {
+            if (_state.FactoryLayer == null)
+            {
+                return;
+            }
+
+            int cellCount = _state.FactoryLayer.Width * _state.FactoryLayer.Height;
+            EnsureScratchCapacity(cellCount);
+
+            for (int i = 0; i < cellCount; i++)
+            {
+                _state.StructuralIntentWinnerByCell[i] = -1;
+                _state.StructuralIntentWriteStampByCell[i] = -1;
+            }
+
+            int intentCount = _state.StructuralIntentBuffer.Count;
+            for (int i = 0; i < intentCount; i++)
+            {
+                FactoryCommand intent = _state.StructuralIntentBuffer.GetAt(i);
+                if (!TryGetCellIndex(intent.X, intent.Y, out int cellIndex))
+                {
+                    continue;
+                }
+
+                _state.StructuralIntentWinnerByCell[cellIndex] = i;
+                _state.StructuralIntentWriteStampByCell[cellIndex] = i;
+            }
+
+            bool anyMutation = false;
+            for (int i = 0; i < intentCount; i++)
+            {
+                FactoryCommand command = _state.StructuralIntentBuffer.GetAt(i);
+                FactoryCommandResult result = BuildDefaultResult(i, command);
+
+                if (!TryGetCellIndex(command.X, command.Y, out int cellIndex))
+                {
+                    result.FailureReason = FactoryCommandFailureReason.OutOfRange;
+                    _state.CommandResults.TryAdd(result);
+                    continue;
+                }
+
+                if (_state.StructuralIntentWinnerByCell[cellIndex] != i || _state.StructuralIntentWriteStampByCell[cellIndex] != i)
+                {
+                    result.FailureReason = FactoryCommandFailureReason.Unsupported;
+                    _state.CommandResults.TryAdd(result);
+                    continue;
+                }
+
+                switch (command.Type)
+                {
+                    case FactoryCommandType.PlaceBuilding:
+                        anyMutation |= ApplyPlaceCommand(command, tickIndex, ref result);
+                        break;
+                    case FactoryCommandType.RemoveBuilding:
+                        anyMutation |= ApplyRemoveCommand(command, tickIndex, ref result);
+                        break;
+                    case FactoryCommandType.RotateBuilding:
+                        anyMutation |= ApplyRotateCommand(command, tickIndex, ref result);
+                        break;
+                    default:
+                        result.FailureReason = FactoryCommandFailureReason.UnknownCommand;
+                        break;
+                }
+
+                _state.CommandResults.TryAdd(result);
+                if (!result.Success && _state.StopProcessingOnFailure)
+                {
+                    break;
+                }
+            }
+
+            if (anyMutation)
+            {
+                RefreshActiveSets();
+            }
+        }
+
+        private bool ApplyPlaceCommand(FactoryCommand command, int tickIndex, ref FactoryCommandResult result)
+        {
+            if (!BuildableRules.TryGetRule(_state.BuildableRules, command.StateId, out BuildableRuleData buildRule))
+            {
+                result.FailureReason = FactoryCommandFailureReason.MissingBuildRule;
+                return false;
+            }
+
+            bool hasFootprint = TryGetFootprint(command.FootprintId, out FactoryFootprintData footprint);
+            bool canBuild;
+
+            if (hasFootprint)
+            {
+                canBuild = BuildableRules.CanBuildOffsets(
+                    _state.FactoryLayer,
+                    _state.TerrainLayer,
+                    command.X,
+                    command.Y,
+                    footprint.OffsetXs,
+                    footprint.OffsetYs,
+                    footprint.Length,
+                    buildRule,
+                    _state.TerrainResourceChannelIndex);
+            }
+            else
+            {
+                int width = command.FootprintWidth > 0 ? command.FootprintWidth : 1;
+                int height = command.FootprintHeight > 0 ? command.FootprintHeight : 1;
+
+                canBuild = BuildableRules.CanBuildRect(
+                    _state.FactoryLayer,
+                    _state.TerrainLayer,
+                    command.X,
+                    command.Y,
+                    width,
+                    height,
+                    buildRule,
+                    _state.TerrainResourceChannelIndex);
+            }
+
+            if (!canBuild)
+            {
+                result.FailureReason = FactoryCommandFailureReason.NotBuildable;
+                return false;
+            }
+
+            int variantId = GridCellData.SetOrientation(0, command.Orientation);
+            variantId = GridCellData.SetConstructionDestructionStage(variantId, GridCellData.StageFullyBuilt);
+
+            if (hasFootprint)
+            {
+                for (int i = 0; i < footprint.Length; i++)
+                {
+                    int x = command.X + footprint.OffsetXs[i];
+                    int y = command.Y + footprint.OffsetYs[i];
+                    _state.FactoryLayer.TrySetCellState(x, y, command.StateId, variantId, 0u, tickIndex, out _);
+                }
+            }
+            else
+            {
+                int width = command.FootprintWidth > 0 ? command.FootprintWidth : 1;
+                int height = command.FootprintHeight > 0 ? command.FootprintHeight : 1;
+
+                for (int localY = 0; localY < height; localY++)
+                {
+                    int y = command.Y + localY;
+                    for (int localX = 0; localX < width; localX++)
+                    {
+                        int x = command.X + localX;
+                        _state.FactoryLayer.TrySetCellState(x, y, command.StateId, variantId, 0u, tickIndex, out _);
+                    }
+                }
+            }
+
+            result.Success = true;
+            result.FailureReason = FactoryCommandFailureReason.None;
+            result.AppliedStateId = command.StateId;
+            return true;
+        }
+
+        private bool ApplyRemoveCommand(FactoryCommand command, int tickIndex, ref FactoryCommandResult result)
+        {
+            if (!_state.FactoryLayer.TrySetCellState(command.X, command.Y, (int)GridStateId.Empty, 0, 0u, tickIndex, out _))
+            {
+                result.FailureReason = FactoryCommandFailureReason.OutOfRange;
+                return false;
+            }
+
+            result.Success = true;
+            result.FailureReason = FactoryCommandFailureReason.None;
+            result.AppliedStateId = (int)GridStateId.Empty;
+            return true;
+        }
+
+        private bool ApplyRotateCommand(FactoryCommand command, int tickIndex, ref FactoryCommandResult result)
+        {
+            if (!_state.FactoryLayer.TryGet(command.X, command.Y, out GridCellData existingCell))
+            {
+                result.FailureReason = FactoryCommandFailureReason.OutOfRange;
+                return false;
+            }
+
+            if (existingCell.StateId == (int)GridStateId.Empty)
+            {
+                result.FailureReason = FactoryCommandFailureReason.EmptyCell;
+                return false;
+            }
+
+            int nextVariantId = GridCellData.SetOrientation(existingCell.VariantId, command.Orientation);
+            _state.FactoryLayer.TrySetCellState(command.X, command.Y, existingCell.StateId, nextVariantId, existingCell.Flags, tickIndex, out _);
+            result.Success = true;
+            result.FailureReason = FactoryCommandFailureReason.None;
+            result.AppliedStateId = existingCell.StateId;
+            return true;
+        }
+
+        private void RefreshActiveSets()
+        {
+            int cellCount = _state.FactoryLayer.Width * _state.FactoryLayer.Height;
+
+            if (_state.ActiveBeltCellIndices == null || _state.ActiveBeltCellIndices.Length != cellCount)
+            {
+                _state.ActiveBeltCellIndices = new int[cellCount];
+            }
+
+            if (_state.ActiveProcessCellIndices == null || _state.ActiveProcessCellIndices.Length != cellCount)
+            {
+                _state.ActiveProcessCellIndices = new int[cellCount];
+            }
+
+            _state.ActiveBeltCellCount = 0;
+            _state.ActiveProcessCellCount = 0;
+
+            int width = _state.FactoryLayer.Width;
+            int height = _state.FactoryLayer.Height;
+
+            for (int localY = 0; localY < height; localY++)
+            {
+                int y = _state.FactoryLayer.MinY + localY;
+                int rowStart = localY * width;
+
+                for (int localX = 0; localX < width; localX++)
+                {
+                    int x = _state.FactoryLayer.MinX + localX;
+                    if (!_state.FactoryLayer.TryGet(x, y, out GridCellData cell))
+                    {
+                        continue;
+                    }
+
+                    int index = rowStart + localX;
+
+                    if (cell.StateId == (int)GridStateId.Conveyor)
+                    {
+                        _state.ActiveBeltCellIndices[_state.ActiveBeltCellCount++] = index;
+                    }
+
+                    if (cell.StateId == (int)GridStateId.CrafterCore
+                        || cell.StateId == (int)GridStateId.CrafterInputPort
+                        || cell.StateId == (int)GridStateId.CrafterOutputPort)
+                    {
+                        _state.ActiveProcessCellIndices[_state.ActiveProcessCellCount++] = index;
+                    }
+                }
+            }
+        }
+
+        private void EnsureScratchCapacity(int cellCount)
+        {
+            if (_state.StructuralIntentWinnerByCell == null || _state.StructuralIntentWinnerByCell.Length != cellCount)
+            {
+                _state.StructuralIntentWinnerByCell = new int[cellCount];
+            }
+
+            if (_state.StructuralIntentWriteStampByCell == null || _state.StructuralIntentWriteStampByCell.Length != cellCount)
+            {
+                _state.StructuralIntentWriteStampByCell = new int[cellCount];
+            }
+        }
+
+        private bool TryGetFootprint(int footprintId, out FactoryFootprintData footprint)
+        {
+            if (_state.Footprints == null || footprintId < 0 || footprintId >= _state.Footprints.Length)
+            {
+                footprint = default;
+                return false;
+            }
+
+            footprint = _state.Footprints[footprintId];
+            if (footprint.Length <= 0 || footprint.OffsetXs == null || footprint.OffsetYs == null)
+            {
+                footprint = default;
+                return false;
+            }
+
+            if (footprint.Length > footprint.OffsetXs.Length || footprint.Length > footprint.OffsetYs.Length)
+            {
+                footprint = default;
+                return false;
+            }
+
+            return true;
+        }
+
+        private bool TryGetCellIndex(int x, int y, out int cellIndex)
+        {
+            if (_state.FactoryLayer == null || !_state.FactoryLayer.IsInRange(x, y))
+            {
+                cellIndex = -1;
+                return false;
+            }
+
+            int localX = x - _state.FactoryLayer.MinX;
+            int localY = y - _state.FactoryLayer.MinY;
+            cellIndex = (localY * _state.FactoryLayer.Width) + localX;
+            return true;
+        }
+
+        private static FactoryCommandResult BuildDefaultResult(int commandIndex, FactoryCommand command)
+        {
+            return new FactoryCommandResult
+            {
+                CommandIndex = commandIndex,
+                CommandType = command.Type,
+                X = command.X,
+                Y = command.Y,
+                Success = false,
+                FailureReason = FactoryCommandFailureReason.UnknownCommand,
+                AppliedStateId = (int)GridStateId.Empty,
+            };
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/FactoryCoreLoopSystem.cs
@@ -1,0 +1,43 @@
+namespace FactoryMustScale.Simulation.Domains.Factory.Systems
+{
+    using FactoryMustScale.Simulation.Core;
+    using FactoryMustScale.Simulation.Domains.Factory.Systems.Build;
+
+    /// <summary>
+    /// Factory domain phase orchestrator under the canonical PreCompute/Compute/Commit contract.
+    ///
+    /// Current wiring:
+    /// - PreCompute: delegates structural edit ingest + early commit to build structural system.
+    /// - Compute: delegates to build structural system (read-only placeholder for now).
+    /// - Commit: delegates to build structural system (reserved for future non-structural deltas).
+    ///
+    /// Additional domain systems (for example transport/crafting/power) should be added here in
+    /// deterministic fixed order as they are refactored into non-legacy ISimSystem components.
+    /// </summary>
+    public sealed class FactoryCoreLoopSystem : ISimSystem
+    {
+        private FactoryBuildStructuralSystem _buildStructuralSystem;
+
+        public FactoryCoreLoopSystem(in FactoryBuildSystemState initialState)
+        {
+            _buildStructuralSystem = new FactoryBuildStructuralSystem(in initialState);
+        }
+
+        public FactoryBuildSystemState BuildState => _buildStructuralSystem.State;
+
+        public void PreCompute(ref SimContext ctx)
+        {
+            _buildStructuralSystem.PreCompute(ref ctx);
+        }
+
+        public void Compute(ref SimContext ctx)
+        {
+            _buildStructuralSystem.Compute(ref ctx);
+        }
+
+        public void Commit(ref SimContext ctx)
+        {
+            _buildStructuralSystem.Commit(ref ctx);
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
@@ -8,7 +8,7 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
     /// Thin adapter that executes the existing item transport phase system inside the SimLoop 3-phase contract.
     ///
     /// Legacy mapping under canonical 3-phase loop:
-    /// - ExternalIngest => SimEvent buffer ingest (BeginTick + PromoteQueuedEvents), no authoritative writes.
+    /// - PreCompute => SimEvent buffer ingest (BeginTick + PromoteQueuedEvents), no authoritative writes.
     /// - Compute => ItemTransportPhaseSystem.Run + PublishEvents to produce deterministic intents/queued events.
     /// - Commit => ItemTransportPhaseSystem.IngestEvents applies queued transport events to authoritative state.
     /// </summary>
@@ -21,13 +21,13 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
             _state = initialState;
         }
 
-        public int ExternalIngestRunCount { get; private set; }
+        public int PreComputeRunCount { get; private set; }
 
         public int ComputeRunCount { get; private set; }
 
         public int CommitRunCount { get; private set; }
 
-        public void ExternalIngest(ref SimContext ctx)
+        public void PreCompute(ref SimContext ctx)
         {
             if (!ctx.Clock.IsFactoryTick)
             {
@@ -37,7 +37,7 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
             _state.SimEvents.EnsureCapacity(_state.SimEventCapacity > 0 ? _state.SimEventCapacity : 128);
             _state.SimEvents.BeginTick();
             _state.SimEvents.PromoteQueuedEvents();
-            ExternalIngestRunCount++;
+            PreComputeRunCount++;
         }
 
         public void Compute(ref SimContext ctx)

--- a/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
@@ -1,6 +1,6 @@
-using FactoryMustScale.Simulation.Legacy;
+using FactoryMustScale.Simulation;
 using FactoryMustScale.Simulation.Core;
-using FactoryMustScale.Simulation.Legacy;
+using FactoryMustScale.Simulation.Domains.Factory.Systems.Build;
 using NUnit.Framework;
 
 namespace FactoryMustScale.Tests.EditMode.Core
@@ -8,56 +8,114 @@ namespace FactoryMustScale.Tests.EditMode.Core
     public sealed class FactoryCoreLoopSystemTests
     {
         [Test]
-        public void Tick_RunsPhasesInDeterministicOrder()
+        public void PreCompute_StructuralCommit_HappensBeforeCompute()
         {
-            var initialState = new FactoryCoreLoopState
+            Layer terrain = new Layer(0, 0, 1, 1, payloadChannelCount: 1);
+            Layer factory = new Layer(0, 0, 1, 1, payloadChannelCount: 0);
+            terrain.TrySetCellState(0, 0, (int)TerrainType.Ground, 0, 0u, currentTick: 0, out _);
+            terrain.TrySetPayload(0, 0, 0, (int)ResourceType.None);
+
+            FactoryBuildSystemState state = CreateState(terrain, factory);
+            state.CommandQueue.TryEnqueue(new FactoryCommand
             {
-                Running = true,
-                MaxFactoryTicks = 5,
-                FactoryTicksExecuted = 0,
-                PhaseTraceBuffer = new int[10],
-                PhaseTraceCount = 0,
-            };
+                Type = FactoryCommandType.PlaceBuilding,
+                X = 0,
+                Y = 0,
+                StateId = (int)GridStateId.Conveyor,
+                Orientation = (int)CellOrientation.Left,
+                FootprintWidth = 1,
+                FootprintHeight = 1,
+            });
 
-            var harness = new FixedStepSimulationHarness<FactoryCoreLoopState, FactoryCoreLoopSystem>(
-                initialState,
-                new FactoryCoreLoopSystem());
+            var buildSystem = new FactoryCoreLoopSystem(in state);
+            var probe = new ComputeProbeSystem(factory, 0, 0);
+            var loop = new SimLoop(new ISimSystem[] { buildSystem, probe });
 
-            harness.Tick(1);
+            loop.Tick(new SimClock(4));
 
-            Assert.That(harness.State.FactoryTicksExecuted, Is.EqualTo(1));
-            Assert.That(harness.State.PhaseTraceCount, Is.EqualTo(3));
-            Assert.That(harness.State.PhaseTraceBuffer[0], Is.EqualTo((0 * 10) + (int)FactoryTickStep.EventCommit));
-            Assert.That(harness.State.PhaseTraceBuffer[1], Is.EqualTo((0 * 10) + (int)FactoryTickStep.CellProcess));
-            Assert.That(harness.State.PhaseTraceBuffer[2], Is.EqualTo((0 * 10) + (int)FactoryTickStep.EventCache));
+            Assert.That(probe.ObservedStateIdInCompute, Is.EqualTo((int)GridStateId.Conveyor));
+            Assert.That(probe.ObservedOrientationInCompute, Is.EqualTo(CellOrientation.Left));
+
+            Assert.That(factory.TryGet(0, 0, out GridCellData cell), Is.True);
+            Assert.That(cell.StateId, Is.EqualTo((int)GridStateId.Conveyor));
+            Assert.That(GridCellData.GetOrientationEnum(cell.VariantId), Is.EqualTo(CellOrientation.Left));
         }
 
         [Test]
-        public void Tick_UpdatesPerPhaseCountersAndStopsAtMaxTicks()
+        public void Compute_DoesNotMutateGridCellData_ChangeCountStableWithoutIntents()
         {
-            const int maxTicks = 3;
+            Layer terrain = new Layer(0, 0, 1, 1, payloadChannelCount: 1);
+            Layer factory = new Layer(0, 0, 1, 1, payloadChannelCount: 0);
+            terrain.TrySetCellState(0, 0, (int)TerrainType.Ground, 0, 0u, currentTick: 0, out _);
+            terrain.TrySetPayload(0, 0, 0, (int)ResourceType.None);
 
-            var initialState = new FactoryCoreLoopState
+            factory.TrySetCellState(0, 0, (int)GridStateId.Conveyor, 0, 0u, currentTick: 0, out GridCellData initialCell);
+
+            FactoryBuildSystemState state = CreateState(terrain, factory);
+            var buildSystem = new FactoryCoreLoopSystem(in state);
+            var loop = new SimLoop(new ISimSystem[] { buildSystem });
+
+            loop.Tick(new SimClock(4));
+
+            Assert.That(factory.TryGet(0, 0, out GridCellData after), Is.True);
+            Assert.That(after.ChangeCount, Is.EqualTo(initialCell.ChangeCount));
+        }
+
+        private static FactoryBuildSystemState CreateState(Layer terrain, Layer factory)
+        {
+            return new FactoryBuildSystemState
             {
-                Running = true,
-                MaxFactoryTicks = maxTicks,
-                FactoryTicksExecuted = 0,
-                PhaseTraceBuffer = new int[20],
-                PhaseTraceCount = 0,
+                TerrainLayer = terrain,
+                FactoryLayer = factory,
+                TerrainResourceChannelIndex = 0,
+                BuildableRules = new[]
+                {
+                    new BuildableRuleData
+                    {
+                        StateId = (int)GridStateId.Conveyor,
+                        AllowedTerrains = TerrainTypeMask.Ground,
+                        AllowedResources = ResourceTypeMask.NoneResource,
+                    }
+                },
+                CommandQueue = new FactoryCommandQueue(capacity: 8),
+                StructuralIntentBuffer = new FactoryCommandQueue(capacity: 8),
+                CommandResults = new FactoryCommandResultBuffer(capacity: 8),
             };
+        }
 
-            var harness = new FixedStepSimulationHarness<FactoryCoreLoopState, FactoryCoreLoopSystem>(
-                initialState,
-                new FactoryCoreLoopSystem());
+        private sealed class ComputeProbeSystem : ISimSystem
+        {
+            private readonly Layer _factory;
+            private readonly int _x;
+            private readonly int _y;
 
-            harness.Tick(maxTicks + 2);
+            public ComputeProbeSystem(Layer factory, int x, int y)
+            {
+                _factory = factory;
+                _x = x;
+                _y = y;
+                ObservedOrientationInCompute = CellOrientation.Invalid;
+            }
 
-            Assert.That(harness.State.FactoryTicksExecuted, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.Running, Is.False);
-            Assert.That(harness.State.InputAndEventHandlingCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.CellProcessUpdateCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.PublishEventsForNextTickCount, Is.EqualTo(maxTicks));
-            Assert.That(harness.State.PhaseTraceCount, Is.EqualTo(maxTicks * 3));
+            public int ObservedStateIdInCompute { get; private set; }
+            public CellOrientation ObservedOrientationInCompute { get; private set; }
+
+            public void PreCompute(ref SimContext ctx)
+            {
+            }
+
+            public void Compute(ref SimContext ctx)
+            {
+                if (_factory.TryGet(_x, _y, out GridCellData cell))
+                {
+                    ObservedStateIdInCompute = cell.StateId;
+                    ObservedOrientationInCompute = GridCellData.GetOrientationEnum(cell.VariantId);
+                }
+            }
+
+            public void Commit(ref SimContext ctx)
+            {
+            }
         }
     }
 }

--- a/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryCoreLoopSystemTests.cs
@@ -1,6 +1,6 @@
 using FactoryMustScale.Simulation;
 using FactoryMustScale.Simulation.Core;
-using FactoryMustScale.Simulation.Domains.Factory.Systems.Build;
+using FactoryMustScale.Simulation.Domains.Factory.Systems;
 using NUnit.Framework;
 
 namespace FactoryMustScale.Tests.EditMode.Core

--- a/Assets/Tests/EditMode/Core/FactoryTransportLegacyAdapterTests.cs
+++ b/Assets/Tests/EditMode/Core/FactoryTransportLegacyAdapterTests.cs
@@ -24,7 +24,7 @@ namespace FactoryMustScale.Tests.EditMode.Core
                 loop.Tick();
             }
 
-            Assert.That(adapter.ExternalIngestRunCount, Is.EqualTo(2));
+            Assert.That(adapter.PreComputeRunCount, Is.EqualTo(2));
             Assert.That(adapter.ComputeRunCount, Is.EqualTo(2));
             Assert.That(adapter.CommitRunCount, Is.EqualTo(2));
         }

--- a/Assets/Tests/EditMode/Core/SimLoopPhaseTraceTests.cs
+++ b/Assets/Tests/EditMode/Core/SimLoopPhaseTraceTests.cs
@@ -21,7 +21,7 @@ namespace FactoryMustScale.Tests.EditMode.Core
             Assert.That(loop.TryGetPhaseTraceAt(1, out int trace1), Is.True);
             Assert.That(loop.TryGetPhaseTraceAt(2, out int trace2), Is.True);
 
-            Assert.That(trace0, Is.EqualTo((1 * 10) + (int)SimPhase.ExternalIngest));
+            Assert.That(trace0, Is.EqualTo((1 * 10) + (int)SimPhase.PreCompute));
             Assert.That(trace1, Is.EqualTo((1 * 10) + (int)SimPhase.Compute));
             Assert.That(trace2, Is.EqualTo((1 * 10) + (int)SimPhase.Commit));
         }

--- a/Assets/Tests/EditMode/Core/SimulationLoopDriverTests.cs
+++ b/Assets/Tests/EditMode/Core/SimulationLoopDriverTests.cs
@@ -45,7 +45,7 @@ namespace FactoryMustScale.Tests.EditMode.Core
                 Assert.That(systems[0], Is.TypeOf<FactoryTransportLegacyAdapter>());
 
                 var adapter = (FactoryTransportLegacyAdapter)systems[0];
-                Assert.That(adapter.ExternalIngestRunCount, Is.EqualTo(1));
+                Assert.That(adapter.PreComputeRunCount, Is.EqualTo(1));
                 Assert.That(adapter.ComputeRunCount, Is.EqualTo(1));
                 Assert.That(adapter.CommitRunCount, Is.EqualTo(1));
             }

--- a/Assets/Tests/EditMode/FactoryCellProcessDefinitionTests.cs
+++ b/Assets/Tests/EditMode/FactoryCellProcessDefinitionTests.cs
@@ -139,13 +139,13 @@ namespace FactoryMustScale.Tests.EditMode
         public void GridCellData_ProcessProfileId_RoundTripsInVariantCodeBits()
         {
             int variantId = 0;
-            variantId = GridCellData.SetProcessProfileId(variantId, processProfileId: 55);
+            variantId = GridCellData.SetProcessProfileId(variantId, processProfileId: 31);
 
-            Assert.That(GridCellData.GetProcessProfileId(variantId), Is.EqualTo(55));
+            Assert.That(GridCellData.GetProcessProfileId(variantId), Is.EqualTo(31));
 
             variantId = GridCellData.SetOrientation(variantId, CellOrientation.Left);
             Assert.That(GridCellData.GetOrientationEnum(variantId), Is.EqualTo(CellOrientation.Left));
-            Assert.That(GridCellData.GetProcessProfileId(variantId), Is.EqualTo(55));
+            Assert.That(GridCellData.GetProcessProfileId(variantId), Is.EqualTo(31));
         }
 
         [Test]

--- a/Assets/Tests/EditMode/GridCellDataTests.cs
+++ b/Assets/Tests/EditMode/GridCellDataTests.cs
@@ -85,6 +85,28 @@ namespace FactoryMustScale.Tests.EditMode
         }
 
         [Test]
+        public void ShapeAndVariant5_RoundTripAcrossFullRanges_WithoutTouchingOrientationOrStage()
+        {
+            for (int shape = 0; shape <= 3; shape++)
+            {
+                for (int profile = 0; profile <= 31; profile++)
+                {
+                    int variantId = 0;
+                    variantId = GridCellData.SetOrientation(variantId, CellOrientation.DownRight);
+                    variantId = GridCellData.SetConstructionDestructionStage(variantId, GridCellData.StageConstructionEnd);
+
+                    variantId = GridCellData.SetShapeCode(variantId, (byte)shape);
+                    variantId = GridCellData.SetVariant5(variantId, (byte)profile);
+
+                    Assert.That(GridCellData.GetShapeCode(variantId), Is.EqualTo((byte)shape));
+                    Assert.That(GridCellData.GetVariant5(variantId), Is.EqualTo((byte)profile));
+                    Assert.That(GridCellData.GetOrientationEnum(variantId), Is.EqualTo(CellOrientation.DownRight));
+                    Assert.That(GridCellData.GetConstructionDestructionStage(variantId), Is.EqualTo(GridCellData.StageConstructionEnd));
+                }
+            }
+        }
+
+        [Test]
         public void FlagHelpers_ReturnExpectedBooleanValues()
         {
             uint flags = 0u;

--- a/Docs/NamespaceStructure.md
+++ b/Docs/NamespaceStructure.md
@@ -377,8 +377,11 @@ FactoryMustScale.Simulation.Domains.Factory.Systems
 
 ### Build
 
-- `Build/FactoryCoreLoopSystem.cs`
-  Implements ISimSystem with PreCompute(A/B): ingest structural intents, then early-commit build/remove/rotate so Compute observes updated cells in the same tick.
+- `FactoryCoreLoopSystem.cs`
+  Factory domain master orchestrator that sequences factory sub-systems per phase in deterministic order.
+
+- `Build/FactoryBuildStructuralSystem.cs`
+  Structural cell edit implementation (PreCompute A/B): ingest structural intents, then early-commit build/remove/rotate so Compute observes updated cells in the same tick.
 
 - `State/FactoryBuildSystemState.cs`
   Holds deterministic command/result buffers, scratch arrays, and active-cell sets for structural edits.

--- a/Docs/NamespaceStructure.md
+++ b/Docs/NamespaceStructure.md
@@ -377,8 +377,11 @@ FactoryMustScale.Simulation.Domains.Factory.Systems
 
 ### Build
 
-- `FactoryBuildSystem.cs`  
-  Applies building placement/removal logic.
+- `Build/FactoryCoreLoopSystem.cs`
+  Implements ISimSystem with PreCompute(A/B): ingest structural intents, then early-commit build/remove/rotate so Compute observes updated cells in the same tick.
+
+- `State/FactoryBuildSystemState.cs`
+  Holds deterministic command/result buffers, scratch arrays, and active-cell sets for structural edits.
 
 ---
 

--- a/Docs/NamespaceStructure.md
+++ b/Docs/NamespaceStructure.md
@@ -4,11 +4,14 @@ This document defines the canonical folder structure, namespaces, and responsibi
 
 The simulation follows a strict **3-phase loop**:
 
-1. **ExternalIngest** — read external commands/intents. No authoritative state mutation (except explicitly allowed fast writes).
+1. **PreCompute** — two deterministic substeps:
+   - A) ingest external commands/intents into transient buffers (no authoritative mutation)
+   - B) structural early commit for cell modifications only (build/remove/rotate)
 2. **Compute** — read-only logic. Produce intents/deltas.
 3. **Commit** — apply deltas to authoritative state.
 
-Only **Commit** may mutate authoritative simulation state.
+Only structural cell edits may mutate authoritative state during **PreCompute(B)**.
+All non-structural mutations must remain in **Commit**.
 
 ---
 
@@ -50,7 +53,7 @@ FactoryMustScale.Simulation.Core
   Maintains authoritative tick counters (UnitTick = 32 Hz; FactoryTick = every 4; EnvTick = every 32).
 
 - `SimLoop.cs`  
-  Executes ExternalIngest → Compute → Commit in deterministic order.
+  Executes PreCompute → Compute → Commit in deterministic order.
 
 - `ISimSystem.cs`  
   Defines the 3-phase system interface contract.
@@ -251,7 +254,7 @@ FactoryMustScale.Simulation.Domains.Terrain.Systems
 
 ### Fast
 
-- `TerrainExternalIngestSystem.cs`  
+- `TerrainPreComputeSystem.cs`
   Applies fast external terrain writes (e.g., item drops).
 
 ### Slow


### PR DESCRIPTION
### Motivation

- Replace the old `ExternalIngest` phase with a clearer `PreCompute` phase to explicitly model two substeps: ingesting external intents and an early structural commit step for cell edits (build/remove/rotate). 
- Ensure the process/profile id packed into variant bits is constrained to the 5-bit range and surface editor-time errors for out-of-range values. 
- Update adapters, tests, and documentation to follow the new 3-phase contract and validate bit-packing behavior.

### Description

- Renamed `ISimSystem.ExternalIngest` to `PreCompute`, updated `SimPhase` enum, `SimLoop`, `SimContext`, and all system implementations to call `PreCompute` instead of `ExternalIngest` to reflect the new phase semantics. 
- Updated `SimLoopSmokeTestSystem`, `FactoryTransportLegacyAdapter` (renamed counter to `PreComputeRunCount`), and the simulation driver to use the new `PreCompute` API and trace markers. 
- Added an editor-only bounds check and error log in `GridCellData.SetProcessProfileId` to warn when a supplied `processProfileId` exceeds the 5-bit range, and adjusted calls/tests to use the valid `0..31` range. 
- Added test coverage: a new `ShapeAndVariant5_RoundTripAcrossFullRanges_WithoutTouchingOrientationOrStage` test and multiple test updates to assert `PreCompute` behavior and correct process profile round-tripping, and updated `Docs/NamespaceStructure.md` to document the new `PreCompute` substeps.

### Testing

- Ran the EditMode unit tests touching the core loop and grid domains including `SimLoopPhaseTraceTests`, `FactoryTransportLegacyAdapterTests`, `SimulationLoopDriverTests`, `GridCellDataTests`, and `FactoryCellProcessDefinitionTests`, and they passed. 
- Ran the EditMode test assembly for the modified areas to validate phase traces, adapter counters, and variant bit round-trips and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d020c4bf48327af12dbacec482183)