### PR TITLE
Optional post-commit SimHash instrumentation with EditMode determinism tests

### DIFF
--- a/Assets/Scripts/FactoryMustScale/Simulation/Common/Grid/Layer.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Common/Grid/Layer.cs
@@ -144,6 +144,30 @@ namespace FactoryMustScale.Simulation
             return true;
         }
 
+        public void AppendDeterministicHash(ref Core.SimHashBuilder builder)
+        {
+            builder.AppendInt(_minX);
+            builder.AppendInt(_minY);
+            builder.AppendInt(_width);
+            builder.AppendInt(_height);
+            builder.AppendInt(_payloadChannelCount);
+
+            for (int i = 0; i < _cells.Length; i++)
+            {
+                GridCellData cell = _cells[i];
+                builder.AppendInt(cell.StateId);
+                builder.AppendInt(cell.VariantId);
+                builder.AppendUInt(cell.Flags);
+                builder.AppendInt(cell.LastUpdatedTick);
+                builder.AppendInt(cell.ChangeCount);
+            }
+
+            for (int i = 0; i < _payloadValues.Length; i++)
+            {
+                builder.AppendInt(_payloadValues[i]);
+            }
+        }
+
         private bool TryGetPayloadIndex(int x, int y, int channelIndex, out int payloadIndex)
         {
             if (channelIndex < 0 || channelIndex >= _payloadChannelCount)

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/ISimHashSource.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/ISimHashSource.cs
@@ -1,0 +1,10 @@
+namespace FactoryMustScale.Simulation.Core
+{
+    /// <summary>
+    /// Optional deterministic hash contributor for post-commit instrumentation.
+    /// </summary>
+    public interface ISimHashSource
+    {
+        void AppendHash(ref SimHashBuilder builder);
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimContext.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimContext.cs
@@ -11,15 +11,21 @@ namespace FactoryMustScale.Simulation.Core
     public struct SimContext
     {
         private readonly int[] _phaseTraceBuffer;
+        private readonly ISimHashSource[] _hashSources;
+        private readonly int _hashSourceCount;
 
-        public SimContext(in SimClock clock, int[] phaseTraceBuffer)
+        public SimContext(in SimClock clock, int[] phaseTraceBuffer, ISimHashSource[] hashSources, int hashSourceCount)
         {
             Clock = clock;
             _phaseTraceBuffer = phaseTraceBuffer;
+            _hashSources = hashSources;
+            _hashSourceCount = hashSourceCount;
             PhaseTraceCount = 0;
         }
 
         public SimClock Clock { get; }
+
+        public int HashSourceCount => _hashSourceCount;
 
         public int PhaseTraceCount { get; private set; }
 
@@ -44,6 +50,18 @@ namespace FactoryMustScale.Simulation.Core
 
             traceValue = _phaseTraceBuffer[index];
             return true;
+        }
+
+        public bool TryGetHashSource(int index, out ISimHashSource source)
+        {
+            if (_hashSources == null || index < 0 || index >= _hashSourceCount)
+            {
+                source = null;
+                return false;
+            }
+
+            source = _hashSources[index];
+            return source != null;
         }
     }
 

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimHash.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimHash.cs
@@ -1,16 +1,71 @@
 namespace FactoryMustScale.Simulation.Core
 {
     /// <summary>
-    /// Deterministic state hash helper (stub).
+    /// Deterministic state hash helper for post-commit instrumentation.
     /// </summary>
     public static class SimHash
     {
-        public static int Fold(int seed, int value)
+        public static ulong ComputeHash(in SimContext context)
+        {
+            SimHashBuilder builder = SimHashBuilder.Create();
+            builder.AppendInt(context.Clock.UnitTick);
+
+            int sourceCount = context.HashSourceCount;
+            for (int i = 0; i < sourceCount; i++)
+            {
+                if (context.TryGetHashSource(i, out ISimHashSource source))
+                {
+                    source.AppendHash(ref builder);
+                }
+            }
+
+            return builder.ToHash();
+        }
+    }
+
+    public struct SimHashBuilder
+    {
+        private const ulong Offset = 1469598103934665603UL;
+        private const ulong Prime = 1099511628211UL;
+
+        private ulong _value;
+
+        public static SimHashBuilder Create()
+        {
+            SimHashBuilder builder;
+            builder._value = Offset;
+            return builder;
+        }
+
+        public void AppendInt(int value)
+        {
+            AppendUInt(unchecked((uint)value));
+        }
+
+        public void AppendUInt(uint value)
         {
             unchecked
             {
-                return (seed * 397) ^ value;
+                _value ^= value & 0xFFu;
+                _value *= Prime;
+                _value ^= (value >> 8) & 0xFFu;
+                _value *= Prime;
+                _value ^= (value >> 16) & 0xFFu;
+                _value *= Prime;
+                _value ^= (value >> 24) & 0xFFu;
+                _value *= Prime;
             }
+        }
+
+        public void AppendULong(ulong value)
+        {
+            AppendUInt((uint)value);
+            AppendUInt((uint)(value >> 32));
+        }
+
+        public ulong ToHash()
+        {
+            return _value;
         }
     }
 }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Core/SimLoop.cs
@@ -7,10 +7,19 @@ namespace FactoryMustScale.Simulation.Core
     /// </summary>
     public sealed class SimLoop
     {
+        public const int HashHistorySize = 256;
+
         private readonly ISimSystem[] _systems;
+        private readonly ISimHashSource[] _hashSources;
+        private readonly int[] _hashTickBuffer;
+        private readonly ulong[] _hashValueBuffer;
         private readonly int[] _phaseTraceBuffer;
         private int _unitTick;
         private int _phaseTraceCount;
+        private int _hashWriteIndex;
+        private int _hashCount;
+
+        public static bool EnableHashChecks { get; set; }
 
         public SimLoop(ISimSystem[] systems, int traceCapacity = 1024)
         {
@@ -25,14 +34,33 @@ namespace FactoryMustScale.Simulation.Core
             }
 
             _systems = systems;
+            _hashSources = new ISimHashSource[systems.Length];
+            int hashSourceCount = 0;
+            for (int i = 0; i < systems.Length; i++)
+            {
+                if (systems[i] is ISimHashSource hashSource)
+                {
+                    _hashSources[hashSourceCount] = hashSource;
+                    hashSourceCount++;
+                }
+            }
+
             _phaseTraceBuffer = traceCapacity == 0 ? Array.Empty<int>() : new int[traceCapacity];
+            _hashTickBuffer = new int[HashHistorySize];
+            _hashValueBuffer = new ulong[HashHistorySize];
             _unitTick = 0;
             _phaseTraceCount = 0;
+            HashSourceCount = hashSourceCount;
+            _hashWriteIndex = 0;
+            _hashCount = 0;
         }
 
         public int UnitTick => _unitTick;
+        public int HashSourceCount { get; }
 
         public int PhaseTraceCount => _phaseTraceCount;
+
+        public int HashRecordCount => _hashCount;
 
         public bool TryGetPhaseTraceAt(int index, out int traceValue)
         {
@@ -55,13 +83,30 @@ namespace FactoryMustScale.Simulation.Core
         {
             _unitTick = clock.UnitTick;
 
-            SimContext ctx = new SimContext(in clock, _phaseTraceBuffer);
+            SimContext ctx = new SimContext(in clock, _phaseTraceBuffer, _hashSources, HashSourceCount);
 
             ExecutePhase(ref ctx, SimPhase.PreCompute);
             ExecutePhase(ref ctx, SimPhase.Compute);
             ExecutePhase(ref ctx, SimPhase.Commit);
+            TryRecordSimHash(in ctx);
 
             _phaseTraceCount = ctx.PhaseTraceCount;
+        }
+
+        public bool TryGetHashRecordAt(int index, out int tickIndex, out ulong hashValue)
+        {
+            if (index < 0 || index >= _hashCount)
+            {
+                tickIndex = 0;
+                hashValue = 0UL;
+                return false;
+            }
+
+            int oldestIndex = _hashCount == HashHistorySize ? _hashWriteIndex : 0;
+            int ringIndex = (oldestIndex + index) % HashHistorySize;
+            tickIndex = _hashTickBuffer[ringIndex];
+            hashValue = _hashValueBuffer[ringIndex];
+            return true;
         }
 
         private void ExecutePhase(ref SimContext ctx, SimPhase phase)
@@ -82,6 +127,24 @@ namespace FactoryMustScale.Simulation.Core
                 }
 
                 ctx.AppendPhaseTrace(phase);
+            }
+        }
+
+        private void TryRecordSimHash(in SimContext context)
+        {
+            if (!EnableHashChecks)
+            {
+                return;
+            }
+
+            ulong hash = SimHash.ComputeHash(in context);
+            _hashTickBuffer[_hashWriteIndex] = context.Clock.UnitTick;
+            _hashValueBuffer[_hashWriteIndex] = hash;
+            _hashWriteIndex = (_hashWriteIndex + 1) % HashHistorySize;
+
+            if (_hashCount < HashHistorySize)
+            {
+                _hashCount++;
             }
         }
     }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Build/FactoryBuildStructuralSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Build/FactoryBuildStructuralSystem.cs
@@ -10,7 +10,7 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Build
     /// - Compute: read-only for GridCellData.
     /// - Commit: reserved for non-structural deltas.
     /// </summary>
-    public sealed class FactoryBuildStructuralSystem : ISimSystem
+    public sealed class FactoryBuildStructuralSystem : ISimSystem, ISimHashSource
     {
         private FactoryBuildSystemState _state;
 
@@ -40,6 +40,51 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Build
 
         public void Commit(ref SimContext ctx)
         {
+        }
+
+        public void AppendHash(ref SimHashBuilder builder)
+        {
+            if (_state.TerrainLayer != null)
+            {
+                _state.TerrainLayer.AppendDeterministicHash(ref builder);
+            }
+
+            if (_state.FactoryLayer != null)
+            {
+                _state.FactoryLayer.AppendDeterministicHash(ref builder);
+            }
+
+            int beltCount = _state.ActiveBeltCellCount;
+            if (_state.ActiveBeltCellIndices == null || beltCount < 0)
+            {
+                beltCount = 0;
+            }
+            else if (beltCount > _state.ActiveBeltCellIndices.Length)
+            {
+                beltCount = _state.ActiveBeltCellIndices.Length;
+            }
+
+            builder.AppendInt(beltCount);
+            for (int i = 0; i < beltCount; i++)
+            {
+                builder.AppendInt(_state.ActiveBeltCellIndices[i]);
+            }
+
+            int processCount = _state.ActiveProcessCellCount;
+            if (_state.ActiveProcessCellIndices == null || processCount < 0)
+            {
+                processCount = 0;
+            }
+            else if (processCount > _state.ActiveProcessCellIndices.Length)
+            {
+                processCount = _state.ActiveProcessCellIndices.Length;
+            }
+
+            builder.AppendInt(processCount);
+            for (int i = 0; i < processCount; i++)
+            {
+                builder.AppendInt(_state.ActiveProcessCellIndices[i]);
+            }
         }
 
         private void IngestStructuralIntents()

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/FactoryCoreLoopSystem.cs
@@ -14,7 +14,7 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems
     /// Additional domain systems (for example transport/crafting/power) should be added here in
     /// deterministic fixed order as they are refactored into non-legacy ISimSystem components.
     /// </summary>
-    public sealed class FactoryCoreLoopSystem : ISimSystem
+    public sealed class FactoryCoreLoopSystem : ISimSystem, ISimHashSource
     {
         private FactoryBuildStructuralSystem _buildStructuralSystem;
 
@@ -38,6 +38,11 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems
         public void Commit(ref SimContext ctx)
         {
             _buildStructuralSystem.Commit(ref ctx);
+        }
+
+        public void AppendHash(ref SimHashBuilder builder)
+        {
+            _buildStructuralSystem.AppendHash(ref builder);
         }
     }
 }

--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
@@ -12,7 +12,7 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
     /// - Compute => ItemTransportPhaseSystem.Run + PublishEvents to produce deterministic intents/queued events.
     /// - Commit => ItemTransportPhaseSystem.IngestEvents applies queued transport events to authoritative state.
     /// </summary>
-    public sealed class FactoryTransportLegacyAdapter : ISimSystem
+    public sealed class FactoryTransportLegacyAdapter : ISimSystem, ISimHashSource
     {
         private FactoryCoreLoopState _state;
 
@@ -61,6 +61,40 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
 
             ItemTransportPhaseSystem.IngestEvents(ref _state);
             CommitRunCount++;
+        }
+
+        public void AppendHash(ref SimHashBuilder builder)
+        {
+            if (_state.FactoryLayer != null)
+            {
+                _state.FactoryLayer.AppendDeterministicHash(ref builder);
+            }
+
+            builder.AppendInt(_state.FactoryTicksExecuted);
+            AppendArray(ref builder, _state.StorageItemCountByCell, _state.StorageItemCountByCell != null ? _state.StorageItemCountByCell.Length : 0);
+            AppendArray(ref builder, _state.ItemPayloadByCell, _state.ItemPayloadByCell != null ? _state.ItemPayloadByCell.Length : 0);
+            AppendArray(ref builder, _state.ItemTransportProgressByCell, _state.ItemTransportProgressByCell != null ? _state.ItemTransportProgressByCell.Length : 0);
+            AppendArray(ref builder, _state.ItemMergerRoundRobinCursorByCell, _state.ItemMergerRoundRobinCursorByCell != null ? _state.ItemMergerRoundRobinCursorByCell.Length : 0);
+        }
+
+        private static void AppendArray(ref SimHashBuilder builder, int[] values, int activeCount)
+        {
+            if (values == null || activeCount <= 0)
+            {
+                builder.AppendInt(0);
+                return;
+            }
+
+            if (activeCount > values.Length)
+            {
+                activeCount = values.Length;
+            }
+
+            builder.AppendInt(activeCount);
+            for (int i = 0; i < activeCount; i++)
+            {
+                builder.AppendInt(values[i]);
+            }
         }
     }
 }

--- a/Assets/Tests/EditMode/Core/SimLoopHashDeterminismTests.cs
+++ b/Assets/Tests/EditMode/Core/SimLoopHashDeterminismTests.cs
@@ -1,0 +1,187 @@
+using FactoryMustScale.Simulation;
+using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Domains.Factory.Systems;
+using NUnit.Framework;
+
+namespace FactoryMustScale.Tests.EditMode.Core
+{
+    public sealed class SimLoopHashDeterminismTests
+    {
+        [SetUp]
+        public void SetUp()
+        {
+            SimLoop.EnableHashChecks = false;
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            SimLoop.EnableHashChecks = false;
+        }
+
+        [Test]
+        public void DeterministicReplay_ProducesIdenticalHashSequence()
+        {
+            const int tickCount = 8;
+
+            ulong[] firstRun = RunScenario(withStructuralDifference: false, tickCount: tickCount);
+            ulong[] secondRun = RunScenario(withStructuralDifference: false, tickCount: tickCount);
+
+            Assert.That(firstRun.Length, Is.EqualTo(tickCount));
+            Assert.That(secondRun.Length, Is.EqualTo(tickCount));
+            for (int i = 0; i < tickCount; i++)
+            {
+                Assert.That(secondRun[i], Is.EqualTo(firstRun[i]));
+            }
+        }
+
+        [Test]
+        public void DivergenceDetection_StructuralDifferenceChangesHash()
+        {
+            const int tickCount = 8;
+
+            ulong[] baseline = RunScenario(withStructuralDifference: false, tickCount: tickCount);
+            ulong[] divergent = RunScenario(withStructuralDifference: true, tickCount: tickCount);
+
+            bool anyDifference = false;
+            for (int i = 0; i < tickCount; i++)
+            {
+                if (baseline[i] != divergent[i])
+                {
+                    anyDifference = true;
+                    break;
+                }
+            }
+
+            Assert.That(anyDifference, Is.True);
+        }
+
+        [Test]
+        public void HashDisabledByDefault_DoesNotRecordHashes()
+        {
+            Layer terrain = new Layer(0, 0, 2, 2, payloadChannelCount: 1);
+            Layer factory = new Layer(0, 0, 2, 2, payloadChannelCount: 2);
+            InitializeGround(terrain, 2, 2);
+
+            FactoryBuildSystemState state = CreateState(terrain, factory);
+            var system = new FactoryCoreLoopSystem(in state);
+            var loop = new SimLoop(new ISimSystem[] { system });
+
+            loop.Tick(new SimClock(4));
+            loop.Tick(new SimClock(8));
+
+            Assert.That(SimLoop.EnableHashChecks, Is.False);
+            Assert.That(loop.HashRecordCount, Is.EqualTo(0));
+        }
+
+        private static ulong[] RunScenario(bool withStructuralDifference, int tickCount)
+        {
+            SimLoop.EnableHashChecks = true;
+
+            Layer terrain = new Layer(0, 0, 2, 2, payloadChannelCount: 1);
+            Layer factory = new Layer(0, 0, 2, 2, payloadChannelCount: 2);
+            InitializeGround(terrain, 2, 2);
+
+            FactoryBuildSystemState state = CreateState(terrain, factory);
+            var system = new FactoryCoreLoopSystem(in state);
+            var loop = new SimLoop(new ISimSystem[] { system });
+
+            EnqueueCommonCommands(state.CommandQueue);
+            if (withStructuralDifference)
+            {
+                state.CommandQueue.TryEnqueue(new FactoryCommand
+                {
+                    Type = FactoryCommandType.PlaceBuilding,
+                    X = 1,
+                    Y = 1,
+                    StateId = (int)GridStateId.Conveyor,
+                    Orientation = (int)CellOrientation.Left,
+                    FootprintWidth = 1,
+                    FootprintHeight = 1,
+                });
+            }
+
+            for (int i = 0; i < tickCount; i++)
+            {
+                loop.Tick(new SimClock((i + 1) * 4));
+            }
+
+            ulong[] hashes = new ulong[loop.HashRecordCount];
+            for (int i = 0; i < loop.HashRecordCount; i++)
+            {
+                bool found = loop.TryGetHashRecordAt(i, out _, out ulong hashValue);
+                Assert.That(found, Is.True);
+                hashes[i] = hashValue;
+            }
+
+            return hashes;
+        }
+
+        private static void EnqueueCommonCommands(FactoryCommandQueue queue)
+        {
+            queue.TryEnqueue(new FactoryCommand
+            {
+                Type = FactoryCommandType.PlaceBuilding,
+                X = 0,
+                Y = 0,
+                StateId = (int)GridStateId.Conveyor,
+                Orientation = (int)CellOrientation.Up,
+                FootprintWidth = 1,
+                FootprintHeight = 1,
+            });
+
+            queue.TryEnqueue(new FactoryCommand
+            {
+                Type = FactoryCommandType.PlaceBuilding,
+                X = 1,
+                Y = 0,
+                StateId = (int)GridStateId.Conveyor,
+                Orientation = (int)CellOrientation.Right,
+                FootprintWidth = 1,
+                FootprintHeight = 1,
+            });
+
+            queue.TryEnqueue(new FactoryCommand
+            {
+                Type = FactoryCommandType.RotateBuilding,
+                X = 1,
+                Y = 0,
+                Orientation = (int)CellOrientation.Down,
+            });
+        }
+
+        private static void InitializeGround(Layer terrain, int width, int height)
+        {
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    terrain.TrySetCellState(x, y, (int)TerrainType.Ground, 0, 0u, currentTick: 0, out _);
+                    terrain.TrySetPayload(x, y, 0, (int)ResourceType.None);
+                }
+            }
+        }
+
+        private static FactoryBuildSystemState CreateState(Layer terrain, Layer factory)
+        {
+            return new FactoryBuildSystemState
+            {
+                TerrainLayer = terrain,
+                FactoryLayer = factory,
+                TerrainResourceChannelIndex = 0,
+                BuildableRules = new[]
+                {
+                    new BuildableRuleData
+                    {
+                        StateId = (int)GridStateId.Conveyor,
+                        AllowedTerrains = TerrainTypeMask.Ground,
+                        AllowedResources = ResourceTypeMask.NoneResource,
+                    }
+                },
+                CommandQueue = new FactoryCommandQueue(capacity: 16),
+                StructuralIntentBuffer = new FactoryCommandQueue(capacity: 16),
+                CommandResults = new FactoryCommandResultBuffer(capacity: 16),
+            };
+        }
+    }
+}

--- a/Assets/Tests/EditMode/Core/SimLoopHashDeterminismTests.cs
+++ b/Assets/Tests/EditMode/Core/SimLoopHashDeterminismTests.cs
@@ -83,10 +83,7 @@ namespace FactoryMustScale.Tests.EditMode.Core
             InitializeGround(terrain, 2, 2);
 
             FactoryBuildSystemState state = CreateState(terrain, factory);
-            var system = new FactoryCoreLoopSystem(in state);
-            var loop = new SimLoop(new ISimSystem[] { system });
-
-            EnqueueCommonCommands(state.CommandQueue);
+            EnqueueCommonCommands(ref state.CommandQueue);
             if (withStructuralDifference)
             {
                 state.CommandQueue.TryEnqueue(new FactoryCommand
@@ -100,6 +97,9 @@ namespace FactoryMustScale.Tests.EditMode.Core
                     FootprintHeight = 1,
                 });
             }
+
+            var system = new FactoryCoreLoopSystem(in state);
+            var loop = new SimLoop(new ISimSystem[] { system });
 
             for (int i = 0; i < tickCount; i++)
             {
@@ -117,7 +117,7 @@ namespace FactoryMustScale.Tests.EditMode.Core
             return hashes;
         }
 
-        private static void EnqueueCommonCommands(FactoryCommandQueue queue)
+        private static void EnqueueCommonCommands(ref FactoryCommandQueue queue)
         {
             queue.TryEnqueue(new FactoryCommand
             {


### PR DESCRIPTION
### Motivation
- Add optional deterministic post-Commit instrumentation to detect replay divergences without affecting gameplay or performance.
- The hash must run only after Commit, be disabled by default in normal play, be enableable in EditMode tests, and avoid per-tick allocations or behavior changes.

### Description
- Call `TryRecordSimHash(context)` immediately after the Commit phase in `SimLoop.Tick(...)`, gated by `SimLoop.EnableHashChecks` and backed by a preallocated ring buffer of size `HashHistorySize = 256` (`_hashTickBuffer`, `_hashValueBuffer`) with `HashRecordCount`/`TryGetHashRecordAt` APIs.
- Introduced `ISimHashSource` and extended `SimContext` to carry a precomputed `ISimHashSource[]` to avoid discovery/allocation in hot paths, and populated that array at `SimLoop` construction time.
- Implemented `SimHash.ComputeHash(in SimContext)` and an allocation-free `SimHashBuilder` struct (FNV-like mixing) with `AppendInt`/`AppendUInt`/`AppendULong`, and wired authoritative contributors only (no intent/delta buffers): `Layer.AppendDeterministicHash`, `FactoryBuildStructuralSystem`/`FactoryCoreLoopSystem`, and `FactoryTransportLegacyAdapter`.
- Added deterministic EditMode tests `Assets/Tests/EditMode/Core/SimLoopHashDeterminismTests.cs` covering replay equality, divergence detection, and disabled-by-default behavior, and the instrumentation is opt-in via `SimLoop.EnableHashChecks`.

### Testing
- Added EditMode tests `SimLoopHashDeterminismTests` (DeterministicReplay, DivergenceDetection, HashDisabledByDefault) under `Assets/Tests/EditMode/Core/` but these tests were not executed here because the Unity EditMode runner is not available in this CLI environment.
- Performed repository smoke checks (`rg`/searches) to verify new symbols wired into `SimLoop`, `SimContext`, and systems, and successfully committed the changes.
- Recommendation: run the new EditMode tests in the Unity Test Runner to validate determinism and ensure no runtime compilation problems in the Unity editor.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dade3eb008327873d367080daba60)