### PR TITLE
Add deterministic debug grid minimap renderer and baked color palettes

### DIFF
--- a/Assets/Scripts/FactoryMustScale/Authoring/GridStateColorPaletteDefinition.cs
+++ b/Assets/Scripts/FactoryMustScale/Authoring/GridStateColorPaletteDefinition.cs
@@ -1,0 +1,69 @@
+using FactoryMustScale.Runtime.Visualization;
+using UnityEngine;
+
+namespace FactoryMustScale.Authoring
+{
+    [System.Serializable]
+    public struct GridStateColorPaletteEntry
+    {
+        public int StateId;
+        public Color32 Color;
+    }
+
+    [CreateAssetMenu(
+        fileName = "GridStateColorPaletteDefinition",
+        menuName = "FactoryMustScale/Definitions/Grid State Color Palette")]
+    /// <summary>
+    /// Authoring palette for debug grid/minimap state colors.
+    /// StateId 0 should be configured to the desired empty-cell color.
+    /// </summary>
+    public sealed class GridStateColorPaletteDefinition : ScriptableObject
+    {
+        [SerializeField]
+        private Color32 _defaultUnknownStateColor = new Color32(255, 0, 255, 255);
+
+        [SerializeField]
+        private GridStateColorPaletteEntry[] _entries;
+
+        public Color32 DefaultUnknownStateColor => _defaultUnknownStateColor;
+        public GridStateColorPaletteEntry[] Entries => _entries;
+
+        public GridStateColorPaletteData Bake()
+        {
+            int maxStateId = 0;
+            if (_entries != null)
+            {
+                for (int i = 0; i < _entries.Length; i++)
+                {
+                    int stateId = _entries[i].StateId;
+                    if (stateId > maxStateId)
+                    {
+                        maxStateId = stateId;
+                    }
+                }
+            }
+
+            var colorsByStateId = new Color32[maxStateId + 1];
+            for (int i = 0; i < colorsByStateId.Length; i++)
+            {
+                colorsByStateId[i] = _defaultUnknownStateColor;
+            }
+
+            if (_entries != null)
+            {
+                for (int i = 0; i < _entries.Length; i++)
+                {
+                    int stateId = _entries[i].StateId;
+                    if (stateId < 0 || stateId >= colorsByStateId.Length)
+                    {
+                        continue;
+                    }
+
+                    colorsByStateId[stateId] = _entries[i].Color;
+                }
+            }
+
+            return new GridStateColorPaletteData(colorsByStateId, _defaultUnknownStateColor);
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Authoring/ItemColorPaletteDefinition.cs
+++ b/Assets/Scripts/FactoryMustScale/Authoring/ItemColorPaletteDefinition.cs
@@ -1,0 +1,78 @@
+using FactoryMustScale.Runtime.Visualization;
+using UnityEngine;
+
+namespace FactoryMustScale.Authoring
+{
+    [System.Serializable]
+    public struct ItemColorPaletteEntry
+    {
+        public int ItemId;
+        public Color32 Color;
+    }
+
+    [CreateAssetMenu(
+        fileName = "ItemColorPaletteDefinition",
+        menuName = "FactoryMustScale/Definitions/Item Color Palette")]
+    /// <summary>
+    /// Authoring palette for payload/item colors used by debug minimap rendering.
+    /// ItemId 0 is "no payload" and should not be drawn as a dot.
+    /// </summary>
+    public sealed class ItemColorPaletteDefinition : ScriptableObject
+    {
+        [SerializeField]
+        private Color32 _defaultUnknownItemColor = new Color32(255, 255, 255, 255);
+
+        [SerializeField]
+        private Color32 _emptyPayloadColor = new Color32(0, 0, 0, 0);
+
+        [SerializeField]
+        private ItemColorPaletteEntry[] _entries;
+
+        public Color32 DefaultUnknownItemColor => _defaultUnknownItemColor;
+        public Color32 EmptyPayloadColor => _emptyPayloadColor;
+        public ItemColorPaletteEntry[] Entries => _entries;
+
+        public ItemColorPaletteData Bake()
+        {
+            int maxItemId = 0;
+            if (_entries != null)
+            {
+                for (int i = 0; i < _entries.Length; i++)
+                {
+                    int itemId = _entries[i].ItemId;
+                    if (itemId > maxItemId)
+                    {
+                        maxItemId = itemId;
+                    }
+                }
+            }
+
+            var colorsByItemId = new Color32[maxItemId + 1];
+            for (int i = 0; i < colorsByItemId.Length; i++)
+            {
+                colorsByItemId[i] = _defaultUnknownItemColor;
+            }
+
+            if (colorsByItemId.Length > 0)
+            {
+                colorsByItemId[0] = _emptyPayloadColor;
+            }
+
+            if (_entries != null)
+            {
+                for (int i = 0; i < _entries.Length; i++)
+                {
+                    int itemId = _entries[i].ItemId;
+                    if (itemId <= 0 || itemId >= colorsByItemId.Length)
+                    {
+                        continue;
+                    }
+
+                    colorsByItemId[itemId] = _entries[i].Color;
+                }
+            }
+
+            return new ItemColorPaletteData(colorsByItemId, _defaultUnknownItemColor, _emptyPayloadColor);
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapRenderer.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapRenderer.cs
@@ -1,0 +1,96 @@
+using FactoryMustScale.Simulation;
+using Unity.Collections;
+using UnityEngine;
+
+namespace FactoryMustScale.Runtime.Visualization
+{
+    /// <summary>
+    /// Debug renderer for grid state + payload that is intended to evolve into the minimap renderer.
+    /// Coordinate convention: y-up simulation indexing and y-up texture addressing (row-major index = x + y * width).
+    /// </summary>
+    public sealed class DebugGridMinimapRenderer
+    {
+        private Texture2D _texture;
+        private int _gridWidth;
+        private int _gridHeight;
+        private int _cellPixelSize;
+        private int _textureWidth;
+
+        public Texture2D Texture => _texture;
+
+        public void Initialize(int width, int height, int cellPixelSize = 3)
+        {
+            _gridWidth = width;
+            _gridHeight = height;
+            _cellPixelSize = cellPixelSize < 1 ? 1 : cellPixelSize;
+            _textureWidth = _gridWidth * _cellPixelSize;
+            int textureHeight = _gridHeight * _cellPixelSize;
+
+            _texture = new Texture2D(_textureWidth, textureHeight, TextureFormat.ARGB32, mipChain: false, linear: false)
+            {
+                filterMode = FilterMode.Point,
+                wrapMode = TextureWrapMode.Clamp,
+            };
+        }
+
+        public void Render(
+            GridCellData[] cells,
+            int width,
+            int height,
+            int[] itemIdByCell,
+            in GridStateColorPaletteData statePalette,
+            in ItemColorPaletteData itemPalette)
+        {
+            if (_texture == null
+                || cells == null
+                || itemIdByCell == null
+                || width != _gridWidth
+                || height != _gridHeight)
+            {
+                return;
+            }
+
+            int cellCount = width * height;
+            if (cells.Length < cellCount || itemIdByCell.Length < cellCount)
+            {
+                return;
+            }
+
+            NativeArray<Color32> rawPixels = _texture.GetRawTextureData<Color32>();
+            int centerOffset = _cellPixelSize / 2;
+
+            for (int y = 0; y < height; y++)
+            {
+                int rowCellOffset = y * width;
+                int blockRowStart = y * _cellPixelSize;
+
+                for (int x = 0; x < width; x++)
+                {
+                    int cellIndex = rowCellOffset + x;
+                    Color32 stateColor = statePalette.ResolveStateColor(cells[cellIndex].StateId);
+
+                    int blockXStart = x * _cellPixelSize;
+                    for (int py = 0; py < _cellPixelSize; py++)
+                    {
+                        int pixelRowStart = (blockRowStart + py) * _textureWidth + blockXStart;
+                        for (int px = 0; px < _cellPixelSize; px++)
+                        {
+                            rawPixels[pixelRowStart + px] = stateColor;
+                        }
+                    }
+
+                    int itemId = itemIdByCell[cellIndex];
+                    if (itemId != 0)
+                    {
+                        int dotX = blockXStart + centerOffset;
+                        int dotY = blockRowStart + centerOffset;
+                        int dotIndex = dotX + dotY * _textureWidth;
+                        rawPixels[dotIndex] = itemPalette.ResolveItemColor(itemId);
+                    }
+                }
+            }
+
+            _texture.Apply(updateMipmaps: false, makeNoLongerReadable: false);
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapTestScenario.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapTestScenario.cs
@@ -1,0 +1,152 @@
+using FactoryMustScale.Simulation;
+
+namespace FactoryMustScale.Runtime.Visualization
+{
+    /// <summary>
+    /// Deterministic runtime harness used by DebugGridMinimapView.
+    /// This is intentionally minimal debug scaffolding (not production simulation systems).
+    /// </summary>
+    public sealed class DebugGridMinimapTestScenario
+    {
+        private const int ProducedItemId = 1;
+        private readonly int[] _pathCellIndices;
+        private readonly int _minerOutputIndex;
+        private readonly int _storageInputIndex;
+        private readonly int _minerPeriodTicks;
+
+        private int _tick;
+        private int _storedCount;
+
+        public DebugGridMinimapTestScenario(int width, int height, GridCellData[] cells, int[] itemIdByCell, int[] pathCellIndices, int minerPeriodTicks)
+        {
+            Width = width;
+            Height = height;
+            Cells = cells;
+            ItemIdByCell = itemIdByCell;
+            _pathCellIndices = pathCellIndices;
+            _minerPeriodTicks = minerPeriodTicks < 1 ? 1 : minerPeriodTicks;
+            _minerOutputIndex = pathCellIndices[0];
+            _storageInputIndex = pathCellIndices[pathCellIndices.Length - 1];
+        }
+
+        public int Width { get; }
+        public int Height { get; }
+        public GridCellData[] Cells { get; }
+        public int[] ItemIdByCell { get; }
+        public int StoredCount => _storedCount;
+
+        public void Tick(int ticks)
+        {
+            int boundedTicks = ticks < 0 ? 0 : ticks;
+            for (int i = 0; i < boundedTicks; i++)
+            {
+                StepOnce();
+            }
+        }
+
+        private void StepOnce()
+        {
+            _tick++;
+
+            for (int i = _pathCellIndices.Length - 2; i >= 0; i--)
+            {
+                int fromIndex = _pathCellIndices[i];
+                int toIndex = _pathCellIndices[i + 1];
+
+                if (toIndex == _storageInputIndex)
+                {
+                    int payloadAtStorageInput = ItemIdByCell[toIndex];
+                    if (payloadAtStorageInput != 0)
+                    {
+                        _storedCount += 1;
+                        ItemIdByCell[toIndex] = 0;
+                    }
+                }
+
+                int payload = ItemIdByCell[fromIndex];
+                if (payload == 0 || ItemIdByCell[toIndex] != 0)
+                {
+                    continue;
+                }
+
+                ItemIdByCell[toIndex] = payload;
+                ItemIdByCell[fromIndex] = 0;
+            }
+
+            if ((_tick % _minerPeriodTicks) == 0 && ItemIdByCell[_minerOutputIndex] == 0)
+            {
+                ItemIdByCell[_minerOutputIndex] = ProducedItemId;
+            }
+        }
+
+        public static DebugGridMinimapTestScenario CreateDefaultSShape()
+        {
+            const int width = 32;
+            const int height = 16;
+            const int minerPeriodTicks = 6;
+
+            int cellCount = width * height;
+            var cells = new GridCellData[cellCount];
+            var itemIdByCell = new int[cellCount];
+
+            int[] path = BuildSPath(width);
+            for (int i = 0; i < path.Length; i++)
+            {
+                int cellIndex = path[i];
+                GridCellData cell = cells[cellIndex];
+                cell.StateId = (int)GridStateId.Conveyor;
+                cells[cellIndex] = cell;
+            }
+
+            GridCellData minerCell = cells[path[0]];
+            minerCell.StateId = (int)GridStateId.Miner;
+            cells[path[0]] = minerCell;
+
+            GridCellData storageCell = cells[path[path.Length - 1]];
+            storageCell.StateId = (int)GridStateId.Storage;
+            cells[path[path.Length - 1]] = storageCell;
+
+            return new DebugGridMinimapTestScenario(width, height, cells, itemIdByCell, path, minerPeriodTicks);
+        }
+
+        private static int[] BuildSPath(int width)
+        {
+            const int left = 2;
+            const int right = 28;
+            const int topY = 12;
+            const int midY = 8;
+            const int bottomY = 4;
+
+            int length = (right - left + 1) + (topY - midY) + (right - left) + (midY - bottomY) + (right - left);
+            var path = new int[length];
+            int writeIndex = 0;
+
+            for (int x = left; x <= right; x++)
+            {
+                path[writeIndex++] = x + topY * width;
+            }
+
+            for (int y = topY - 1; y >= midY; y--)
+            {
+                path[writeIndex++] = right + y * width;
+            }
+
+            for (int x = right - 1; x >= left; x--)
+            {
+                path[writeIndex++] = x + midY * width;
+            }
+
+            for (int y = midY - 1; y >= bottomY; y--)
+            {
+                path[writeIndex++] = left + y * width;
+            }
+
+            for (int x = left + 1; x <= right; x++)
+            {
+                path[writeIndex++] = x + bottomY * width;
+            }
+
+            return path;
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapView.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapView.cs
@@ -11,6 +11,8 @@ namespace FactoryMustScale.Runtime.Visualization
     /// </summary>
     public sealed class DebugGridMinimapView : MonoBehaviour
     {
+        private const float SimTickIntervalSeconds = 0.25f;
+
         [Header("Palettes")]
         [SerializeField]
         private GridStateColorPaletteDefinition _statePaletteAsset;
@@ -31,13 +33,11 @@ namespace FactoryMustScale.Runtime.Visualization
         [SerializeField]
         private Renderer _targetQuadRenderer;
 
-        [SerializeField, Min(1)]
-        private int _simTicksPerFrame = 1;
-
         private DebugGridMinimapRenderer _renderer;
         private DebugGridMinimapTestScenario _scenario;
         private GridStateColorPaletteData _statePalette;
         private ItemColorPaletteData _itemPalette;
+        private float _simTickAccumulatorSeconds;
 
         private void Start()
         {
@@ -63,6 +63,22 @@ namespace FactoryMustScale.Runtime.Visualization
             _renderer = new DebugGridMinimapRenderer();
             _renderer.Initialize(_scenario.Width, _scenario.Height, _cellPixelSize);
             BindTextureTargets(_renderer.Texture);
+            RenderCurrentState();
+        }
+
+        private void FixedUpdate()
+        {
+            if (_renderer == null || _scenario == null)
+            {
+                return;
+            }
+
+            _simTickAccumulatorSeconds += Time.fixedDeltaTime;
+            while (_simTickAccumulatorSeconds >= SimTickIntervalSeconds)
+            {
+                _scenario.Tick(1);
+                _simTickAccumulatorSeconds -= SimTickIntervalSeconds;
+            }
         }
 
         private void Update()
@@ -72,7 +88,11 @@ namespace FactoryMustScale.Runtime.Visualization
                 return;
             }
 
-            _scenario.Tick(_simTicksPerFrame);
+            RenderCurrentState();
+        }
+
+        private void RenderCurrentState()
+        {
             _renderer.Render(
                 _scenario.Cells,
                 _scenario.Width,

--- a/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapView.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/Visualization/DebugGridMinimapView.cs
@@ -1,0 +1,122 @@
+using FactoryMustScale.Authoring;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace FactoryMustScale.Runtime.Visualization
+{
+    /// <summary>
+    /// Drop this component on any GameObject in a scene, assign palette assets, then press Play.
+    /// If no targets are assigned, it auto-creates a Canvas + RawImage for quick debug use.
+    /// Debug scaffold today; intended to evolve into a production minimap view later.
+    /// </summary>
+    public sealed class DebugGridMinimapView : MonoBehaviour
+    {
+        [Header("Palettes")]
+        [SerializeField]
+        private GridStateColorPaletteDefinition _statePaletteAsset;
+
+        [SerializeField]
+        private ItemColorPaletteDefinition _itemPaletteAsset;
+
+        [Header("Renderer")]
+        [SerializeField]
+        private int _cellPixelSize = 3;
+
+        [SerializeField]
+        private bool _autoCreateTestScenario = true;
+
+        [SerializeField]
+        private RawImage _targetUI;
+
+        [SerializeField]
+        private Renderer _targetQuadRenderer;
+
+        [SerializeField, Min(1)]
+        private int _simTicksPerFrame = 1;
+
+        private DebugGridMinimapRenderer _renderer;
+        private DebugGridMinimapTestScenario _scenario;
+        private GridStateColorPaletteData _statePalette;
+        private ItemColorPaletteData _itemPalette;
+
+        private void Start()
+        {
+            _statePalette = _statePaletteAsset != null
+                ? _statePaletteAsset.Bake()
+                : new GridStateColorPaletteData(new[] { new Color32(0, 0, 0, 255) }, new Color32(255, 0, 255, 255));
+
+            _itemPalette = _itemPaletteAsset != null
+                ? _itemPaletteAsset.Bake()
+                : new ItemColorPaletteData(new[] { new Color32(0, 0, 0, 0), new Color32(255, 255, 0, 255) }, new Color32(255, 255, 255, 255), new Color32(0, 0, 0, 0));
+
+            if (_autoCreateTestScenario)
+            {
+                _scenario = DebugGridMinimapTestScenario.CreateDefaultSShape();
+            }
+
+            if (_scenario == null)
+            {
+                enabled = false;
+                return;
+            }
+
+            _renderer = new DebugGridMinimapRenderer();
+            _renderer.Initialize(_scenario.Width, _scenario.Height, _cellPixelSize);
+            BindTextureTargets(_renderer.Texture);
+        }
+
+        private void Update()
+        {
+            if (_renderer == null || _scenario == null)
+            {
+                return;
+            }
+
+            _scenario.Tick(_simTicksPerFrame);
+            _renderer.Render(
+                _scenario.Cells,
+                _scenario.Width,
+                _scenario.Height,
+                _scenario.ItemIdByCell,
+                in _statePalette,
+                in _itemPalette);
+        }
+
+        private void BindTextureTargets(Texture texture)
+        {
+            if (_targetUI == null && _targetQuadRenderer == null)
+            {
+                _targetUI = CreateDefaultUiTarget();
+            }
+
+            if (_targetUI != null)
+            {
+                _targetUI.texture = texture;
+            }
+
+            if (_targetQuadRenderer != null)
+            {
+                _targetQuadRenderer.material.mainTexture = texture;
+            }
+        }
+
+        private RawImage CreateDefaultUiTarget()
+        {
+            var canvasGo = new GameObject("DebugGridMinimapCanvas", typeof(Canvas), typeof(CanvasScaler), typeof(GraphicRaycaster));
+            var canvas = canvasGo.GetComponent<Canvas>();
+            canvas.renderMode = RenderMode.ScreenSpaceOverlay;
+
+            var rawImageGo = new GameObject("DebugGridMinimap", typeof(RectTransform), typeof(RawImage));
+            rawImageGo.transform.SetParent(canvasGo.transform, false);
+
+            var rect = rawImageGo.GetComponent<RectTransform>();
+            rect.anchorMin = new Vector2(0f, 0f);
+            rect.anchorMax = new Vector2(0f, 0f);
+            rect.pivot = new Vector2(0f, 0f);
+            rect.anchoredPosition = new Vector2(16f, 16f);
+            rect.sizeDelta = new Vector2(_scenario.Width * _cellPixelSize, _scenario.Height * _cellPixelSize);
+
+            return rawImageGo.GetComponent<RawImage>();
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Runtime/Visualization/GridStateColorPaletteData.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/Visualization/GridStateColorPaletteData.cs
@@ -1,0 +1,30 @@
+using UnityEngine;
+
+namespace FactoryMustScale.Runtime.Visualization
+{
+    /// <summary>
+    /// Runtime color lookup for cell state ids.
+    /// Baked from ScriptableObject authoring and used in minimap hot paths (array lookup, no dictionary).
+    /// </summary>
+    public struct GridStateColorPaletteData
+    {
+        private readonly Color32[] _colorsByStateId;
+        private readonly Color32 _defaultUnknownStateColor;
+
+        public GridStateColorPaletteData(Color32[] colorsByStateId, Color32 defaultUnknownStateColor)
+        {
+            _colorsByStateId = colorsByStateId;
+            _defaultUnknownStateColor = defaultUnknownStateColor;
+        }
+
+        public Color32 ResolveStateColor(int stateId)
+        {
+            if (stateId >= 0 && stateId < _colorsByStateId.Length)
+            {
+                return _colorsByStateId[stateId];
+            }
+
+            return _defaultUnknownStateColor;
+        }
+    }
+}

--- a/Assets/Scripts/FactoryMustScale/Runtime/Visualization/ItemColorPaletteData.cs
+++ b/Assets/Scripts/FactoryMustScale/Runtime/Visualization/ItemColorPaletteData.cs
@@ -1,0 +1,33 @@
+using UnityEngine;
+
+namespace FactoryMustScale.Runtime.Visualization
+{
+    /// <summary>
+    /// Runtime color lookup for item ids.
+    /// ItemId 0 is reserved for no payload.
+    /// </summary>
+    public struct ItemColorPaletteData
+    {
+        private readonly Color32[] _colorsByItemId;
+        private readonly Color32 _defaultUnknownItemColor;
+
+        public ItemColorPaletteData(Color32[] colorsByItemId, Color32 defaultUnknownItemColor, Color32 emptyPayloadColor)
+        {
+            _colorsByItemId = colorsByItemId;
+            _defaultUnknownItemColor = defaultUnknownItemColor;
+            EmptyPayloadColor = emptyPayloadColor;
+        }
+
+        public Color32 EmptyPayloadColor { get; }
+
+        public Color32 ResolveItemColor(int itemId)
+        {
+            if (itemId >= 0 && itemId < _colorsByItemId.Length)
+            {
+                return _colorsByItemId[itemId];
+            }
+
+            return _defaultUnknownItemColor;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a low-overhead, deterministic debug renderer that will evolve into the minimap and allow visual inspection of grid state and per-cell payloads without touching simulation hot paths. 
- Expose authoring-friendly ScriptableObject palettes that bake to array-backed runtime data so render-time color lookup is dictionary-free and deterministic. 
- Include a minimal deterministic test harness so the view can be validated quickly in the Editor without integrating the full simulation stack.

### Description
- Added authoring ScriptableObjects `GridStateColorPaletteDefinition` and `ItemColorPaletteDefinition` (under `Assets/Scripts/FactoryMustScale/Authoring/`) which `Bake()` into runtime, array-backed palette structs and ensure `StateId==0` and `ItemId==0` are handled predictably. 
- Added runtime palette structs `GridStateColorPaletteData` and `ItemColorPaletteData` (under `Runtime/Visualization/`) implementing deterministic id->color resolution using arrays (no `Dictionary` in hot path). 
- Implemented `DebugGridMinimapRenderer` (non-MonoBehaviour) that owns a `Texture2D`, exposes `Initialize(width,height,cellPixelSize)`, writes pixels via `Texture2D.GetRawTextureData<Color32>()` with no per-frame allocations, fills each cell as a solid block (default 3x3) using state color, and overlays a 1-pixel center dot when `ItemId != 0`, then calls `_texture.Apply(false, false)` once per frame; coordinate convention is y-up row-major indexing. 
- Implemented `DebugGridMinimapTestScenario` deterministic harness (32x16 S-shaped path) which sets conveyors/miner/storage, produces `ItemId=1` on a fixed cadence, propagates payload along the path, and consumes at storage. 
- Added `DebugGridMinimapView` MonoBehaviour to bake palettes on `Start()`, create/use the test scenario (when `autoCreateTestScenario=true`), initialize the renderer and texture, bind to a `RawImage` or quad (auto-creates a Canvas+RawImage fallback), advance the harness by explicit ticks in `Update()`, and render from the scenario buffers each frame.

### Testing
- Ran repository sanity checks `git diff --check` and `git diff --cached --stat` which produced no issues. 
- Created and committed the changes with `git commit -m "Add debug grid minimap renderer with baked color palettes"` successfully. 
- No automated Unity `EditMode`/`PlayMode` tests were added or executed in this PR; runtime verification should be done in the Unity Editor by adding `DebugGridMinimapView` to a scene, assigning/baking palette assets, and pressing Play as described in the PR summary.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dee9c5d748327841a0917a24dfd70)