### PR TITLE
Deterministic 3-phase belt transport with two-buffer commit

### DIFF
--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/Systems/Transport/FactoryTransportLegacyAdapter.cs
@@ -1,20 +1,29 @@
 namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
 {
-    using FactoryMustScale.Simulation;
     using FactoryMustScale.Simulation.Core;
-    using FactoryMustScale.Simulation.Item;
     using FactoryMustScale.Simulation.Legacy;
 
     /// <summary>
-    /// Thin adapter that executes the existing item transport phase system inside the SimLoop 3-phase contract.
+    /// Deterministic belt-only transport system mapped to the SimLoop 3-phase contract.
     ///
-    /// Legacy mapping under canonical 3-phase loop:
-    /// - PreCompute => SimEvent buffer ingest (BeginTick + PromoteQueuedEvents), no authoritative writes.
-    /// - Compute => ItemTransportPhaseSystem.Run + PublishEvents to produce deterministic intents/queued events.
-    /// - Commit => ItemTransportPhaseSystem.IngestEvents applies queued transport events to authoritative state.
+    /// Tick contract:
+    /// - PreCompute ingests external commands in stable order and clears transient routing buffers.
+    /// - Compute reads authoritative primary buffers only and builds a resolved move plan.
+    /// - Commit performs a full two-buffer apply: copy+advance progress, apply resolved moves, then swap.
+    ///
+    /// The progress rule intentionally clamps at 4 for blocked items: min(progress + 1, 4).
     /// </summary>
     public sealed class FactoryTransportLegacyAdapter : ISimSystem, ISimHashSource
     {
+        public const int EmptyItemId = 0;
+        public const int InvalidIndex = -1;
+        public const int BeltBuildingType = 1;
+
+        public const int CommandPlaceBelt = 1;
+        public const int CommandRemoveCell = 2;
+        public const int CommandRotateCell = 3;
+        public const int CommandInjectItem = 4;
+
         private FactoryCoreLoopState _state;
 
         public FactoryTransportLegacyAdapter(in FactoryCoreLoopState initialState)
@@ -28,13 +37,13 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
 
         public int CommitRunCount { get; private set; }
 
-        public int Width => _state.FactoryLayer != null ? _state.FactoryLayer.Width : 0;
-
-        public int Height => _state.FactoryLayer != null ? _state.FactoryLayer.Height : 0;
-
-        public GridCellData[] Cells => _state.FactoryLayer != null ? _state.FactoryLayer.CellData : null;
-
         public int[] ItemIdByCell => _state.ItemPayloadByCell;
+
+        public int[] ProgressByCell => _state.ItemTransportProgressByCell;
+
+        public int[] DirectionByCell => _state.DirectionByCell;
+
+        public int[] BuildingTypeByCell => _state.BuildingTypeByCell;
 
         public void PreCompute(ref SimContext ctx)
         {
@@ -43,9 +52,20 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
                 return;
             }
 
-            _state.SimEvents.EnsureCapacity(_state.SimEventCapacity > 0 ? _state.SimEventCapacity : 128);
-            _state.SimEvents.BeginTick();
-            _state.SimEvents.PromoteQueuedEvents();
+            int cellCount = ResolveCellCount();
+            if (cellCount > 0)
+            {
+                EnsureBuffers(cellCount);
+                IngestExternalCommands(cellCount);
+                ClearTransientBuffers(cellCount);
+                DerivePerCellFlags(cellCount);
+
+                // Early commit injection point: producers can queue item insertions here in the future.
+                EarlyCommitInjectFromProducers();
+                // Early commit injection point: sinks can queue item removals here in the future.
+                EarlyCommitConsumeToSinks();
+            }
+
             PreComputeRunCount++;
         }
 
@@ -56,8 +76,13 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
                 return;
             }
 
-            ItemTransportPhaseSystem.Run(ref _state);
-            ItemTransportPhaseSystem.PublishEvents(ref _state);
+            int cellCount = ResolveCellCount();
+            if (cellCount > 0)
+            {
+                BuildMoveIntents(cellCount);
+                ResolveConflicts(cellCount);
+            }
+
             ComputeRunCount++;
         }
 
@@ -68,22 +93,365 @@ namespace FactoryMustScale.Simulation.Domains.Factory.Systems.Transport
                 return;
             }
 
-            ItemTransportPhaseSystem.IngestEvents(ref _state);
+            int cellCount = ResolveCellCount();
+            if (cellCount > 0)
+            {
+                InitializeNextBuffers(cellCount);
+                ApplyResolvedMoves(cellCount);
+                SwapPrimaryAndNextBuffers();
+            }
+
             CommitRunCount++;
         }
 
         public void AppendHash(ref SimHashBuilder builder)
         {
-            if (_state.FactoryLayer != null)
-            {
-                _state.FactoryLayer.AppendDeterministicHash(ref builder);
-            }
-
-            builder.AppendInt(_state.FactoryTicksExecuted);
-            AppendArray(ref builder, _state.StorageItemCountByCell, _state.StorageItemCountByCell != null ? _state.StorageItemCountByCell.Length : 0);
             AppendArray(ref builder, _state.ItemPayloadByCell, _state.ItemPayloadByCell != null ? _state.ItemPayloadByCell.Length : 0);
             AppendArray(ref builder, _state.ItemTransportProgressByCell, _state.ItemTransportProgressByCell != null ? _state.ItemTransportProgressByCell.Length : 0);
-            AppendArray(ref builder, _state.ItemMergerRoundRobinCursorByCell, _state.ItemMergerRoundRobinCursorByCell != null ? _state.ItemMergerRoundRobinCursorByCell.Length : 0);
+            AppendArray(ref builder, _state.DirectionByCell, _state.DirectionByCell != null ? _state.DirectionByCell.Length : 0);
+            AppendArray(ref builder, _state.BuildingTypeByCell, _state.BuildingTypeByCell != null ? _state.BuildingTypeByCell.Length : 0);
+        }
+
+        private int ResolveCellCount()
+        {
+            if (_state.ItemPayloadByCell != null)
+            {
+                return _state.ItemPayloadByCell.Length;
+            }
+
+            if (_state.BuildingTypeByCell != null)
+            {
+                return _state.BuildingTypeByCell.Length;
+            }
+
+            return 0;
+        }
+
+        private void EnsureBuffers(int cellCount)
+        {
+            if (_state.ItemPayloadByCell == null || _state.ItemPayloadByCell.Length != cellCount)
+            {
+                _state.ItemPayloadByCell = new int[cellCount];
+            }
+
+            if (_state.ItemNextPayloadByCell == null || _state.ItemNextPayloadByCell.Length != cellCount)
+            {
+                _state.ItemNextPayloadByCell = new int[cellCount];
+            }
+
+            if (_state.ItemTransportProgressByCell == null || _state.ItemTransportProgressByCell.Length != cellCount)
+            {
+                _state.ItemTransportProgressByCell = new int[cellCount];
+            }
+
+            if (_state.ItemNextTransportProgressByCell == null || _state.ItemNextTransportProgressByCell.Length != cellCount)
+            {
+                _state.ItemNextTransportProgressByCell = new int[cellCount];
+            }
+
+            if (_state.BuildingTypeByCell == null || _state.BuildingTypeByCell.Length != cellCount)
+            {
+                _state.BuildingTypeByCell = new int[cellCount];
+            }
+
+            if (_state.DirectionByCell == null || _state.DirectionByCell.Length != cellCount)
+            {
+                _state.DirectionByCell = new int[cellCount];
+            }
+
+            if (_state.ItemIntentTargetBySource == null || _state.ItemIntentTargetBySource.Length != cellCount)
+            {
+                _state.ItemIntentTargetBySource = new int[cellCount];
+            }
+
+            if (_state.ItemResolvedSourceByTarget == null || _state.ItemResolvedSourceByTarget.Length != cellCount)
+            {
+                _state.ItemResolvedSourceByTarget = new int[cellCount];
+            }
+
+            if (_state.ItemResolvedTargetBySource == null || _state.ItemResolvedTargetBySource.Length != cellCount)
+            {
+                _state.ItemResolvedTargetBySource = new int[cellCount];
+            }
+
+            if (_state.IsBeltByCell == null || _state.IsBeltByCell.Length != cellCount)
+            {
+                _state.IsBeltByCell = new bool[cellCount];
+            }
+
+            if (_state.HasItemByCell == null || _state.HasItemByCell.Length != cellCount)
+            {
+                _state.HasItemByCell = new bool[cellCount];
+            }
+
+            if (_state.CanReceiveByCell == null || _state.CanReceiveByCell.Length != cellCount)
+            {
+                _state.CanReceiveByCell = new bool[cellCount];
+            }
+
+            if (_state.OutputTargetIndexByCell == null || _state.OutputTargetIndexByCell.Length != cellCount)
+            {
+                _state.OutputTargetIndexByCell = new int[cellCount];
+            }
+        }
+
+        private void IngestExternalCommands(int cellCount)
+        {
+            int commandCount = _state.CommandCount;
+            if (_state.CommandTypeByIndex == null || _state.CommandCellIndexByIndex == null || _state.CommandDirOrItemIdByIndex == null)
+            {
+                _state.CommandCount = 0;
+                return;
+            }
+
+            if (commandCount > _state.CommandTypeByIndex.Length)
+            {
+                commandCount = _state.CommandTypeByIndex.Length;
+            }
+
+            if (commandCount > _state.CommandCellIndexByIndex.Length)
+            {
+                commandCount = _state.CommandCellIndexByIndex.Length;
+            }
+
+            if (commandCount > _state.CommandDirOrItemIdByIndex.Length)
+            {
+                commandCount = _state.CommandDirOrItemIdByIndex.Length;
+            }
+
+            for (int i = 0; i < commandCount; i++)
+            {
+                int cellIndex = _state.CommandCellIndexByIndex[i];
+                if (cellIndex < 0 || cellIndex >= cellCount)
+                {
+                    continue;
+                }
+
+                int arg = _state.CommandDirOrItemIdByIndex[i];
+                switch (_state.CommandTypeByIndex[i])
+                {
+                    case CommandPlaceBelt:
+                        _state.BuildingTypeByCell[cellIndex] = BeltBuildingType;
+                        _state.DirectionByCell[cellIndex] = arg & 3;
+                        break;
+                    case CommandRemoveCell:
+                        _state.BuildingTypeByCell[cellIndex] = 0;
+                        _state.DirectionByCell[cellIndex] = 0;
+                        _state.ItemPayloadByCell[cellIndex] = EmptyItemId;
+                        _state.ItemTransportProgressByCell[cellIndex] = 0;
+                        break;
+                    case CommandRotateCell:
+                        if (_state.BuildingTypeByCell[cellIndex] == BeltBuildingType)
+                        {
+                            _state.DirectionByCell[cellIndex] = arg & 3;
+                        }
+
+                        break;
+                    case CommandInjectItem:
+                        if (_state.BuildingTypeByCell[cellIndex] == BeltBuildingType && _state.ItemPayloadByCell[cellIndex] == EmptyItemId)
+                        {
+                            _state.ItemPayloadByCell[cellIndex] = arg;
+                            _state.ItemTransportProgressByCell[cellIndex] = 0;
+                        }
+
+                        break;
+                }
+            }
+
+            _state.CommandCount = 0;
+        }
+
+        private void ClearTransientBuffers(int cellCount)
+        {
+            for (int i = 0; i < cellCount; i++)
+            {
+                _state.ItemIntentTargetBySource[i] = InvalidIndex;
+                _state.ItemResolvedSourceByTarget[i] = InvalidIndex;
+                _state.ItemResolvedTargetBySource[i] = InvalidIndex;
+                _state.OutputTargetIndexByCell[i] = InvalidIndex;
+            }
+        }
+
+        private void DerivePerCellFlags(int cellCount)
+        {
+            for (int i = 0; i < cellCount; i++)
+            {
+                bool isBelt = _state.BuildingTypeByCell[i] == BeltBuildingType;
+                bool hasItem = _state.ItemPayloadByCell[i] != EmptyItemId;
+                _state.IsBeltByCell[i] = isBelt;
+                _state.HasItemByCell[i] = hasItem;
+
+                int target = ComputeOutputTargetIndex(i, _state.DirectionByCell[i], cellCount);
+                _state.OutputTargetIndexByCell[i] = target;
+
+                bool canReceive = false;
+                if (target >= 0 && target < cellCount)
+                {
+                    canReceive = _state.BuildingTypeByCell[target] == BeltBuildingType
+                        && _state.ItemPayloadByCell[target] == EmptyItemId;
+                }
+
+                _state.CanReceiveByCell[i] = canReceive;
+            }
+        }
+
+        private int ComputeOutputTargetIndex(int sourceIndex, int direction, int cellCount)
+        {
+            int width = _state.FactoryLayer != null ? _state.FactoryLayer.Width : cellCount;
+            if (width <= 0)
+            {
+                return InvalidIndex;
+            }
+
+            int x = sourceIndex % width;
+            int y = sourceIndex / width;
+
+            switch (direction & 3)
+            {
+                case 0:
+                    y -= 1;
+                    break;
+                case 1:
+                    x += 1;
+                    break;
+                case 2:
+                    y += 1;
+                    break;
+                case 3:
+                    x -= 1;
+                    break;
+            }
+
+            if (x < 0 || x >= width)
+            {
+                return InvalidIndex;
+            }
+
+            int height = cellCount / width;
+            if (y < 0 || y >= height)
+            {
+                return InvalidIndex;
+            }
+
+            int target = (y * width) + x;
+            return (target < 0 || target >= cellCount) ? InvalidIndex : target;
+        }
+
+        private void BuildMoveIntents(int cellCount)
+        {
+            for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+            {
+                if (!_state.IsBeltByCell[sourceIndex] || !_state.HasItemByCell[sourceIndex])
+                {
+                    continue;
+                }
+
+                if (_state.ItemTransportProgressByCell[sourceIndex] < 4)
+                {
+                    continue;
+                }
+
+                int targetIndex = _state.OutputTargetIndexByCell[sourceIndex];
+                if (targetIndex == InvalidIndex)
+                {
+                    continue;
+                }
+
+                if (!_state.CanReceiveByCell[sourceIndex])
+                {
+                    continue;
+                }
+
+                _state.ItemIntentTargetBySource[sourceIndex] = targetIndex;
+            }
+        }
+
+        private void ResolveConflicts(int cellCount)
+        {
+            for (int sourceIndex = 0; sourceIndex < cellCount; sourceIndex++)
+            {
+                int targetIndex = _state.ItemIntentTargetBySource[sourceIndex];
+                if (targetIndex == InvalidIndex)
+                {
+                    continue;
+                }
+
+                int currentWinner = _state.ItemResolvedSourceByTarget[targetIndex];
+                if (currentWinner == InvalidIndex || sourceIndex < currentWinner)
+                {
+                    _state.ItemResolvedSourceByTarget[targetIndex] = sourceIndex;
+                }
+            }
+
+            for (int targetIndex = 0; targetIndex < cellCount; targetIndex++)
+            {
+                int sourceIndex = _state.ItemResolvedSourceByTarget[targetIndex];
+                if (sourceIndex != InvalidIndex)
+                {
+                    _state.ItemResolvedTargetBySource[sourceIndex] = targetIndex;
+                }
+            }
+        }
+
+        private void InitializeNextBuffers(int cellCount)
+        {
+            for (int i = 0; i < cellCount; i++)
+            {
+                int itemId = _state.ItemPayloadByCell[i];
+                _state.ItemNextPayloadByCell[i] = itemId;
+
+                if (itemId != EmptyItemId)
+                {
+                    int nextProgress = _state.ItemTransportProgressByCell[i] + 1;
+                    _state.ItemNextTransportProgressByCell[i] = nextProgress > 4 ? 4 : nextProgress;
+                }
+                else
+                {
+                    _state.ItemNextTransportProgressByCell[i] = 0;
+                }
+            }
+        }
+
+        private void ApplyResolvedMoves(int cellCount)
+        {
+            for (int targetIndex = 0; targetIndex < cellCount; targetIndex++)
+            {
+                int sourceIndex = _state.ItemResolvedSourceByTarget[targetIndex];
+                if (sourceIndex == InvalidIndex)
+                {
+                    continue;
+                }
+
+                int itemId = _state.ItemPayloadByCell[sourceIndex];
+                if (itemId == EmptyItemId)
+                {
+                    continue;
+                }
+
+                _state.ItemNextPayloadByCell[sourceIndex] = EmptyItemId;
+                _state.ItemNextTransportProgressByCell[sourceIndex] = 0;
+                _state.ItemNextPayloadByCell[targetIndex] = itemId;
+                _state.ItemNextTransportProgressByCell[targetIndex] = 0;
+            }
+        }
+
+        private void SwapPrimaryAndNextBuffers()
+        {
+            int[] payload = _state.ItemPayloadByCell;
+            _state.ItemPayloadByCell = _state.ItemNextPayloadByCell;
+            _state.ItemNextPayloadByCell = payload;
+
+            int[] progress = _state.ItemTransportProgressByCell;
+            _state.ItemTransportProgressByCell = _state.ItemNextTransportProgressByCell;
+            _state.ItemNextTransportProgressByCell = progress;
+        }
+
+        private static void EarlyCommitInjectFromProducers()
+        {
+        }
+
+        private static void EarlyCommitConsumeToSinks()
+        {
         }
 
         private static void AppendArray(ref SimHashBuilder builder, int[] values, int activeCount)

--- a/Assets/Scripts/FactoryMustScale/Simulation/Legacy/FactoryCoreLoopSystem.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Legacy/FactoryCoreLoopSystem.cs
@@ -59,11 +59,29 @@ namespace FactoryMustScale.Simulation.Legacy
         public int SimEventCapacity;
         public int[] StorageItemCountByCell;
         public int[] ItemPayloadByCell;
+        public int[] ItemNextPayloadByCell;
         public int[] ItemTransportProgressByCell;
+        public int[] ItemNextTransportProgressByCell;
+        public int[] BuildingTypeByCell;
+        public int[] DirectionByCell;
         public int[] ItemIntentTargetBySource;
+        public int[] ItemResolvedSourceByTarget;
+        public int[] ItemResolvedTargetBySource;
         public int[] ItemWinnerSourceByTarget;
         public int[] ItemWinnerCountByTarget;
         public int[] ItemMergerRoundRobinCursorByCell;
+
+        // Derived/read-only per-tick flags built during PreCompute.
+        public bool[] IsBeltByCell;
+        public bool[] HasItemByCell;
+        public bool[] CanReceiveByCell;
+        public int[] OutputTargetIndexByCell;
+
+        // Minimal placeholder command queue for deterministic PreCompute ingestion.
+        public int[] CommandTypeByIndex;
+        public int[] CommandCellIndexByIndex;
+        public int[] CommandDirOrItemIdByIndex;
+        public int CommandCount;
 
         // Item transport move events queued for current and next tick.
         public int[] ItemMoveEventSourceByIndex;

--- a/Assets/Tests/EditMode/Core/BeltTransportThreePhaseTests.cs
+++ b/Assets/Tests/EditMode/Core/BeltTransportThreePhaseTests.cs
@@ -1,0 +1,134 @@
+using FactoryMustScale.Simulation.Core;
+using FactoryMustScale.Simulation.Domains.Factory.Systems.Transport;
+using FactoryMustScale.Simulation.Legacy;
+using NUnit.Framework;
+
+namespace FactoryMustScale.Tests.EditMode.Core
+{
+    public sealed class BeltTransportThreePhaseTests
+    {
+        [Test]
+        public void Throughput_FiveBelts_MovesOneCellEveryFourFactoryTicks()
+        {
+            FactoryCoreLoopState initialState = CreateFiveBeltLineState();
+            var adapter = new FactoryTransportLegacyAdapter(in initialState);
+            var loop = new SimLoop(new ISimSystem[] { adapter });
+
+            // Tick 0
+            Assert.That(FindItemIndex(adapter.ItemIdByCell), Is.EqualTo(0));
+
+            for (int tick = 1; tick <= 20; tick++)
+            {
+                loop.Tick(new SimClock(tick * 4));
+
+                int expectedIndex = tick / 4;
+                if (expectedIndex > 4)
+                {
+                    expectedIndex = 4;
+                }
+
+                Assert.That(FindItemIndex(adapter.ItemIdByCell), Is.EqualTo(expectedIndex), $"tick={tick}");
+            }
+        }
+
+        [Test]
+        public void Determinism_SameInitialState_ProducesSamePerTickHashes()
+        {
+            const int ticks = 20;
+            ulong[] first = RunScenarioHashes(ticks);
+            ulong[] second = RunScenarioHashes(ticks);
+
+            Assert.That(second.Length, Is.EqualTo(first.Length));
+            for (int i = 0; i < ticks; i++)
+            {
+                Assert.That(second[i], Is.EqualTo(first[i]), $"tick={i}");
+            }
+        }
+
+        private static ulong[] RunScenarioHashes(int ticks)
+        {
+            FactoryCoreLoopState initialState = CreateFiveBeltLineState();
+            var adapter = new FactoryTransportLegacyAdapter(in initialState);
+            var loop = new SimLoop(new ISimSystem[] { adapter });
+            ulong[] hashes = new ulong[ticks];
+
+            for (int tick = 0; tick < ticks; tick++)
+            {
+                loop.Tick(new SimClock((tick + 1) * 4));
+                hashes[tick] = ComputeStateHash(adapter.ItemIdByCell, adapter.ProgressByCell, adapter.DirectionByCell, adapter.BuildingTypeByCell);
+            }
+
+            return hashes;
+        }
+
+        private static FactoryCoreLoopState CreateFiveBeltLineState()
+        {
+            int[] commandType = new int[1];
+            int[] commandCellIndex = new int[1];
+            int[] commandArg = new int[1];
+            commandType[0] = FactoryTransportLegacyAdapter.CommandInjectItem;
+            commandCellIndex[0] = 0;
+            commandArg[0] = 7;
+
+            return new FactoryCoreLoopState
+            {
+                BuildingTypeByCell = new[]
+                {
+                    FactoryTransportLegacyAdapter.BeltBuildingType,
+                    FactoryTransportLegacyAdapter.BeltBuildingType,
+                    FactoryTransportLegacyAdapter.BeltBuildingType,
+                    FactoryTransportLegacyAdapter.BeltBuildingType,
+                    FactoryTransportLegacyAdapter.BeltBuildingType,
+                },
+                DirectionByCell = new[] { 1, 1, 1, 1, 1 },
+                ItemPayloadByCell = new int[5],
+                ItemTransportProgressByCell = new int[5],
+                CommandTypeByIndex = commandType,
+                CommandCellIndexByIndex = commandCellIndex,
+                CommandDirOrItemIdByIndex = commandArg,
+                CommandCount = 1,
+            };
+        }
+
+        private static int FindItemIndex(int[] payload)
+        {
+            for (int i = 0; i < payload.Length; i++)
+            {
+                if (payload[i] != 0)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        private static ulong ComputeStateHash(int[] payload, int[] progress, int[] direction, int[] buildingType)
+        {
+            const ulong offset = 1469598103934665603UL;
+            const ulong prime = 1099511628211UL;
+
+            ulong hash = offset;
+            hash = HashArray(payload, hash, prime);
+            hash = HashArray(progress, hash, prime);
+            hash = HashArray(direction, hash, prime);
+            hash = HashArray(buildingType, hash, prime);
+            return hash;
+        }
+
+        private static ulong HashArray(int[] values, ulong seed, ulong prime)
+        {
+            ulong hash = seed;
+            for (int i = 0; i < values.Length; i++)
+            {
+                unchecked
+                {
+                    hash ^= (uint)values[i];
+                    hash *= prime;
+                }
+            }
+
+            return hash;
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement a minimal deterministic belt transport flow that follows the canonical PreCompute -> Compute -> Commit contract and is suitable for EditMode testing and future extension.
- Provide a simple, capacity-1 conveyor model that moves items after 4 factory ticks with deterministic intent/conflict resolution and no frame-rate dependence.
- Add stable, minimal command ingestion and explicit early-commit injection hooks to allow later producer/sink integration without changing core semantics.

### Description
- Added primary/secondary/transient buffers and a minimal command buffer to `FactoryCoreLoopState` to support two-buffer commits and deterministic PreCompute ingestion.
- Introduced `FactoryTransportLegacyAdapter` implementing a belt-only transport system with clearly separated `PreCompute`, `Compute`, and `Commit` phases, including ingesting placeholder commands, deriving per-cell flags, building move intents, resolving conflicts (lowest source index wins), and applying moves using a two-buffer copy-then-apply-then-swap pattern.
- Progress semantics: per-tick progress increments by +1 for occupied cells and clamps at 4 (i.e., `min(progress+1, 4)`), and progress resets to 0 on successful move or when cell is empty.
- Added two EditMode tests `BeltTransportThreePhaseTests` that validate throughput on a five-belt line (movement every 4 factory ticks) and determinism by comparing per-tick state hashes across two runs.

### Testing
- Repository static checks were run via `git diff --check` and produced no issues.
- No Unity EditMode tests were executed in this environment; the new tests to run in the Unity Test Runner are `FactoryMustScale.Tests.EditMode.Core.BeltTransportThreePhaseTests.Throughput_FiveBelts_MovesOneCellEveryFourFactoryTicks` and `FactoryMustScale.Tests.EditMode.Core.BeltTransportThreePhaseTests.Determinism_SameInitialState_ProducesSamePerTickHashes` (expected to pass).
- Manual compile checks performed by ensuring buffers and public APIs are consistent with existing simulation loop wiring; please run EditMode tests inside Unity to validate behavior end-to-end.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb34621bc832795fd13f21fe6182e)