### PR TITLE
Add canonical FactoryProcessExamples and restore conveyor test compile path

### DIFF
--- a/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/State/FactoryProcessExamples.cs
+++ b/Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/State/FactoryProcessExamples.cs
@@ -1,0 +1,39 @@
+namespace FactoryMustScale.Simulation
+{
+    /// <summary>
+    /// Canonical process presets used by tests and bootstrap code.
+    /// These helpers return fully baked runtime data and do not depend on authoring assets.
+    /// </summary>
+    public static class FactoryProcessExamples
+    {
+        public static FactoryCellProcessData CreateBasicConveyorProcessData()
+        {
+            return new FactoryCellProcessData
+            {
+                StateId = (int)GridStateId.Conveyor,
+                ProcessType = FactoryProcessType.PassThrough,
+                ProcessDurationTicks = 1,
+                ProcessProgressPayloadChannelIndex = -1,
+                InputSlots = new[]
+                {
+                    new FactoryProcessSlotData
+                    {
+                        Directions = CardinalDirectionMask.Up,
+                        ItemIdFilter = 0,
+                        MaxItemsPerTick = 1,
+                    },
+                },
+                OutputSlots = new[]
+                {
+                    new FactoryProcessSlotData
+                    {
+                        Directions = CardinalDirectionMask.Down,
+                        ItemIdFilter = 0,
+                        MaxItemsPerTick = 1,
+                    },
+                },
+                Recipes = new FactoryProcessRecipeData[0],
+            };
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Restore a missing runtime helper used by EditMode tests to fix compile-time breakage for conveyor process examples.
- Provide a canonical, runtime-only conveyor preset so tests and bootstrap code can obtain a fully baked `FactoryCellProcessData` without relying on authoring assets.
- Keep the solution minimal and deterministic to align with simulation/runtime rules in the codebase.

### Description
- Added `FactoryProcessExamples` as a static helper in `Assets/Scripts/FactoryMustScale/Simulation/Domains/Factory/State/FactoryProcessExamples.cs` that returns baked runtime data.
- Implemented `CreateBasicConveyorProcessData()` to return a pass-through conveyor with `StateId = GridStateId.Conveyor`, `ProcessType = FactoryProcessType.PassThrough`, `ProcessDurationTicks = 1`, `ProcessProgressPayloadChannelIndex = -1`, one input slot (Up) and one output slot (Down) with `MaxItemsPerTick = 1`, and an empty `Recipes` array.
- The helper is runtime-only and does not reference ScriptableObjects or authoring types, preserving the authoring/runtime separation.

### Testing
- Confirmed presence and references of the new symbol with `rg` which located `FactoryProcessExamples.CreateBasicConveyorProcessData()` in the tests and new implementation file, and the checks succeeded.
- Verified the new file exists at the intended path and contains the expected public helper returning `FactoryCellProcessData` using a file listing check, which succeeded.
- EditMode Unity tests were not executed because the Unity CLI/test runner is not available in this environment, so `FactoryCellProcessDefinitionTests` could not be run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fc85ec0ac83279f8a2cc232b30fbf)